### PR TITLE
Fixed generator for issues found with Matt 01/25PM

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -83,9 +83,11 @@ TEST - Add "Your hooks should contain ..." to app, service and graphql hooks.ejs
 LATER - findUser & findPost produce with batchloader "null" found at char 681 near: "followed_by": null, "followi
 LATER   graphql/lib/run-time/feathers/extract-items.js#extractAllItems : return [] instead of null x2.
 
+- First field in schema does not default to type: string
 - should paginate values in default.json be app level options?
+- Why is startup so slow? Are we scanning node_modules?
 - add option for semicolons or not
-- create mongodb $jsonSchema model
+OK - create mongodb $jsonSchema model
 - create Sequelize schema
 - create fastJoin definitions
 - create for swagger

--- a/generators/writing/index.js
+++ b/generators/writing/index.js
@@ -3,7 +3,7 @@
 const crypto = require('crypto');
 const deepMerge = require('deepmerge');
 const mongoose = require('mongoose');
-const { camelCase, kebabCase, upperFirst } = require('lodash');
+const { camelCase, kebabCase, snakeCase, upperFirst } = require('lodash');
 const { EOL } = require('os');
 const { existsSync } = require('fs');
 const { inspect } = require('util');
@@ -219,6 +219,7 @@ module.exports = function generatorWriting (generator, what) {
     const specsService = specs.services[name];
     const kebabName = kebabCase(name);
     const camelName = camelCase(name);
+    const snakeName = snakeCase(name);
     const adapter = specsService.adapter;
     const path = specsService.path;
     const isAuthEntityWithAuthentication = specsService.isAuthEntity ? specs.authentication : undefined;
@@ -256,8 +257,9 @@ module.exports = function generatorWriting (generator, what) {
     // Custom template context.
     context = Object.assign({}, context, {
       serviceName: name,
-      kebabName,
       camelName,
+      kebabName,
+      snakeName,
       adapter,
       path: stripSlashes(path),
       authentication: isAuthEntityWithAuthentication,
@@ -283,17 +285,17 @@ module.exports = function generatorWriting (generator, what) {
     const kn = kebabName;
 
     todos = [
-      tmpl([testPath,   'services', 'name.test.ejs'], [testDir, 'services', `${kn}.test.js`],        true ),
-      tmpl([serPath,    '_model', modelTpl],          [libDir, 'models', `${context.modelName}.js`], true, !context.modelName   ),
-      tmpl(mainFileTpl,                               [libDir, 'services', kn, `${kn}.service.js`],  true ),
-      tmpl([namePath,   genericFileTpl],              [libDir, 'services', kn, `${kn}.class.js`],    true, adapter !== 'generic'),
+      tmpl([testPath,   'services', 'name.test.ejs'], [testDir, 'services', `${kn}.test.js`],        ),
+      tmpl([serPath,    '_model', modelTpl],          [libDir, 'models', `${context.modelName}.js`], false, !context.modelName    ),
+      tmpl(mainFileTpl,                               [libDir, 'services', kn, `${kn}.service.js`],  ),
+      tmpl([namePath,   genericFileTpl],              [libDir, 'services', kn, `${kn}.class.js`],    false, adapter !== 'generic' ),
 
-      tmpl([namePath,   'name.schema.ejs'],           [libDir, 'services', kn, `${kn}.schema.js`]   ),
-      tmpl([namePath,   'name.mongo.ejs'],            [libDir, 'services', kn, `${kn}.mongo.js`]    ),
-      tmpl([namePath,   'name.mongoose.ejs'],         [libDir, 'services', kn, `${kn}.mongoose.js`] ),
-      tmpl([namePath,   'name.validate.ejs'],         [libDir, 'services', kn, `${kn}.validate.js`] ),
-      tmpl([namePath,   'name.hooks.ejs'],            [libDir, 'services', kn, `${kn}.hooks.js`]    ),
-      tmpl([serPath,    'index.ejs'],                 [libDir, 'services', 'index.js']              )
+      tmpl([namePath,   'name.schema.ejs'],           [libDir, 'services', kn, `${kn}.schema.js`]    ),
+      tmpl([namePath,   'name.mongo.ejs'],            [libDir, 'services', kn, `${kn}.mongo.js`]     ),
+      tmpl([namePath,   'name.mongoose.ejs'],         [libDir, 'services', kn, `${kn}.mongoose.js`]  ),
+      tmpl([namePath,   'name.validate.ejs'],         [libDir, 'services', kn, `${kn}.validate.js`]  ),
+      tmpl([namePath,   'name.hooks.ejs'],            [libDir, 'services', kn, `${kn}.hooks.js`]     ),
+      tmpl([serPath,    'index.ejs'],                 [libDir, 'services', 'index.js']               )
     ];
 
     // Generate modules

--- a/generators/writing/templates/src/app.ejs
+++ b/generators/writing/templates/src/app.ejs
@@ -29,7 +29,7 @@ const authentication = require('./authentication');
   __temp = specs._adapters[__adapter];
   __module = __temp.substring(0, __temp.length - 3);
 -%>
-const <%- __adapter %> = require('<%- __module %>');
+const <%- __adapter %> = require('./<%- __module %>');
 <% }) -%>
 <%# --- forEach-1 ends above. -%>
 <%- insertFragment('imports') %>

--- a/generators/writing/templates/src/services/_model/knex.ejs
+++ b/generators/writing/templates/src/services/_model/knex.ejs
@@ -1,12 +1,17 @@
-/* eslint-disable no-console */
 
-// <%= serviceName %>-model.js - A KnexJS
+/* eslint-disable no-console */
+// <%= serviceName %>-model.js - A KnexJS model
 // 
 // See http://knexjs.org/
 // for more of what you can do here.
-module.exports = function (app) {
-  const db = app.get('knexClient');
-  const tableName = '<%= snakeName %>';
+<%- insertFragment('knex_imports') %>
+<%- insertFragment('knex_init') %>
+
+let moduleExports = function (app) {
+  let db = app.get('knexClient');
+  let tableName = '<%= snakeName %>';
+  <%- insertFragment('knex_func_init') %>
+
   db.schema.hasTable(tableName).then(exists => {
     if(!exists) {
       db.schema.createTable(tableName, table => {
@@ -17,7 +22,14 @@ module.exports = function (app) {
         .catch(e => console.error(`Error creating ${tableName} table`, e));
     }
   });
-  
 
+  <%- insertFragment('knex_func_return') %>
   return db;
 };
+<%- insertFragment('knex_more') %>
+
+<%- insertFragment('knex_exports') %>
+module.exports = moduleExports;
+
+<%- insertFragment('knex_funcs') %>
+<%- insertFragment('knex_end') %>

--- a/generators/writing/templates/src/services/_model/mongoose-user.ejs
+++ b/generators/writing/templates/src/services/_model/mongoose-user.ejs
@@ -1,21 +1,38 @@
 
-// <%= serviceName %>-model.js - A mongoose model
+// <%= serviceName %>-model.js - A Mongoose model for a user entity
 //
 // See http://mongoosejs.com/docs/models.html
 // for more of what you can do here.
-module.exports = function (app) {
-  const mongooseClient = app.get('mongooseClient');
-  const <%= camelName %> = new mongooseClient.Schema({
-  <% if(authentication.strategies.indexOf('local') !== -1) { %>
-    email: {type: String, unique: true},
-    password: { type: String },
-  <% } %>
-  <% authentication.oauthProviders.forEach(provider => { %>
-    <%= provider.name %>Id: { type: String },
-  <% }); %>
-  }, {
-    timestamps: true
-  });
 
-  return mongooseClient.model('<%= camelName %>', <%= camelName %>);
+<%- insertFragment('mongoose_schema', [
+  `const mongooseSchema = require('../services/${kebabName}/${kebabName}.mongoose');`,
+]) %>
+<%- insertFragment('mongoose_imports') %>
+<%- insertFragment('mongoose_init') %>
+
+let moduleExports = function (app) {
+  let mongooseClient = app.get('mongooseClient');
+  <%- insertFragment('mongoose_func_init') %>
+
+  <%- insertFragment('mongoose_client', [
+    `  const ${camelName} = new mongooseClient.Schema(mongooseSchema, { timestamps: true });`,
+  ]) %>
+
+  let returns = mongooseClient.model('<%= camelName %>', <%= camelName %>);
+
+  <%- insertFragment('mongoose_func_return') %>
+  return returns;
 };
+<%- insertFragment('mongoose_more') %>
+
+<%- insertFragment('mongoose_exports') %>
+module.exports = moduleExports;
+
+<%- insertFragment('mongoose_funcs') %>
+<%- insertFragment('mongoose_end') %>
+
+/*
+<% authentication.oauthProviders.forEach(provider => { %>
+<%= provider.name %>Id: { type: String },
+<% }); %>
+*/

--- a/generators/writing/templates/src/services/_model/mongoose.ejs
+++ b/generators/writing/templates/src/services/_model/mongoose.ejs
@@ -1,16 +1,32 @@
 
-// <%= serviceName %>-model.js - A mongoose model
+// <%= serviceName %>-model.js - A Mongoose model
 // 
 // See http://mongoosejs.com/docs/models.html
 // for more of what you can do here.
-module.exports = function (app) {
-  const mongooseClient = app.get('mongooseClient');
-  const { Schema } = mongooseClient;
-  const <%= camelName %> = new Schema({
-    text: { type: String, required: true }
-  }, {
-    timestamps: true
-  });
 
-  return mongooseClient.model('<%= camelName %>', <%= camelName %>);
+<%- insertFragment('mongoose_schema', [
+  `const mongooseSchema = require('../services/${kebabName}/${kebabName}.mongoose');`,
+]) %>
+<%- insertFragment('mongoose_imports') %>
+<%- insertFragment('mongoose_init') %>
+
+let moduleExports = function (app) {
+  let mongooseClient = app.get('mongooseClient');
+  <%- insertFragment('mongoose_func_init') %>
+
+  <%- insertFragment('mongoose_client', [
+    `  const ${camelName} = new mongooseClient.Schema(mongooseSchema, { timestamps: true });`,
+  ]) %>
+
+  let returns = mongooseClient.model('<%= camelName %>', <%= camelName %>);
+
+  <%- insertFragment('mongoose_func_return') %>
+  return returns;
 };
+<%- insertFragment('mongoose_more') %>
+
+<%- insertFragment('mongoose_exports') %>
+module.exports = moduleExports;
+
+<%- insertFragment('mongoose_funcs') %>
+<%- insertFragment('mongoose_end') %>

--- a/generators/writing/templates/src/services/_model/nedb-user.ejs
+++ b/generators/writing/templates/src/services/_model/nedb-user.ejs
@@ -1,14 +1,27 @@
+
+// <%= serviceName %>-model.js - An nedb model for user entity
 const NeDB = require('nedb');
 const path = require('path');
+<%- insertFragment('nedb_imports') %>
+<%- insertFragment('nedb_init') %>
 
-module.exports = function (app) {
+let moduleExports = function (app) {
   const dbPath = app.get('nedb');
-  const Model = new NeDB({
-    filename: path.join(dbPath, '<%= kebabName %>.db'),
-    autoload: true
-  });
+  <%- insertFragment('nedb_client', [
+  '  let Model = new NeDB({',
+  `    filename: path.join(dbPath, '${kebabName}.db'),`,
+  '    autoload: true',
+  '  });',
+  '  Model.ensureIndex({ fieldName: \'email\', unique: true });',
+  ]) %>
 
-  Model.ensureIndex({ fieldName: 'email', unique: true });
-
+  <%- insertFragment('nedb_func_return') %>
   return Model;
 };
+<%- insertFragment('nedb_more') %>
+
+<%- insertFragment('nedb_exports') %>
+module.exports = moduleExports;
+
+<%- insertFragment('nedb_funcs') %>
+<%- insertFragment('nedb_end') %>

--- a/generators/writing/templates/src/services/_model/nedb.ejs
+++ b/generators/writing/templates/src/services/_model/nedb.ejs
@@ -1,12 +1,26 @@
+
+// <%= serviceName %>-model.js - An nedb model
 const NeDB = require('nedb');
 const path = require('path');
+<%- insertFragment('nedb_imports') %>
+<%- insertFragment('nedb_init') %>
 
-module.exports = function (app) {
+let moduleExports = function (app) {
   const dbPath = app.get('nedb');
-  const Model = new NeDB({
-    filename: path.join(dbPath, '<%= kebabName %>.db'),
-    autoload: true
-  });
+  <%- insertFragment('nedb_client', [
+  '  let Model = new NeDB({',
+  `    filename: path.join(dbPath, '${kebabName}.db'),`,
+  '    autoload: true',
+  '  });',
+  ]) %>
 
+  <%- insertFragment('nedb_func_return') %>
   return Model;
 };
+<%- insertFragment('nedb_more') %>
+
+<%- insertFragment('nedb_exports') %>
+module.exports = moduleExports;
+
+<%- insertFragment('nedb_funcs') %>
+<%- insertFragment('nedb_end') %>

--- a/generators/writing/templates/src/services/_model/sequelize.ejs
+++ b/generators/writing/templates/src/services/_model/sequelize.ejs
@@ -1,10 +1,17 @@
+
+// <%= serviceName %>-model.js - A Sequelize model
+//
 // See http://docs.sequelizejs.com/en/latest/docs/models-definition/
 // for more of what you can do here.
 const Sequelize = require('sequelize');
 const DataTypes = Sequelize.DataTypes;
+<%- insertFragment('sequelize_imports') %>
+<%- insertFragment('sequelize_init') %>
 
-module.exports = function (app) {
-  const sequelizeClient = app.get('sequelizeClient');
+let moduleExports = function (app) {
+  let sequelizeClient = app.get('sequelizeClient');
+  <%- insertFragment('sequelize_func_init') %>
+
   const <%= camelName %> = sequelizeClient.define('<%= snakeName %>', {
     text: {
       type: DataTypes.STRING,
@@ -23,5 +30,13 @@ module.exports = function (app) {
     // See http://docs.sequelizejs.com/en/latest/docs/associations/
   };
 
+  <%- insertFragment('sequelize_func_return') %>
   return <%= camelName %>;
 };
+<%- insertFragment('sequelize_more') %>
+
+<%- insertFragment('sequelize_exports') %>
+module.exports = moduleExports;
+
+<%- insertFragment('sequelize_funcs') %>
+<%- insertFragment('sequelize_end') %>

--- a/generators/writing/templates/src/services/name/name.mongo.ejs
+++ b/generators/writing/templates/src/services/name/name.mongo.ejs
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines the MongoDB $jsonSchema for service `<%= serviceName %>`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 <%- insertFragment('imports') %>

--- a/generators/writing/templates/src/services/name/name.mongoose.ejs
+++ b/generators/writing/templates/src/services/name/name.mongoose.ejs
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines Mongoose model for service `<%= serviceName %>`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 const mongoose = require('mongoose'); // eslint-disable-line no-unused-vars

--- a/lib/service-specs-expand.js
+++ b/lib/service-specs-expand.js
@@ -137,7 +137,7 @@ function expandProperties (feathersSchema, depth = 1) {
   Object.keys(properties || {}).forEach(fieldName => {
     let property = properties[fieldName];
 
-    if (!property.type && depth !== 1) {
+    if (!property.type) {
       if (property.properties) {
         property.type = 'object';
       } else if (property.items) {
@@ -155,7 +155,7 @@ function expandProperties (feathersSchema, depth = 1) {
     }
 
     // Handle model for json-schema { type: 'object', properties: {} }
-    if (property.type === 'object' || depth === 1) {
+    if (property.type === 'object') {
       properties[fieldName] = expandProperties(property, ++depth);
       property = properties[fieldName];
     }

--- a/test/authentication-1.test-expected/src1/models/users-1.model.js
+++ b/test/authentication-1.test-expected/src1/models/users-1.model.js
@@ -1,14 +1,27 @@
+
+// users1-model.js - An nedb model for user entity
 const NeDB = require('nedb');
 const path = require('path');
+//!code: nedb_imports //!end
+//!code: nedb_init //!end
 
-module.exports = function (app) {
+let moduleExports = function (app) {
   const dbPath = app.get('nedb');
-  const Model = new NeDB({
+  //!<DEFAULT> code: nedb_client
+  let Model = new NeDB({
     filename: path.join(dbPath, 'users-1.db'),
     autoload: true
   });
-
   Model.ensureIndex({ fieldName: 'email', unique: true });
+  //!end
 
+  //!code: nedb_func_return //!end
   return Model;
 };
+//!code: nedb_more //!end
+
+//!code: nedb_exports //!end
+module.exports = moduleExports;
+
+//!code: nedb_funcs //!end
+//!code: nedb_end //!end

--- a/test/authentication-1.test-expected/src1/services/users-1/users-1.mongo.js
+++ b/test/authentication-1.test-expected/src1/services/users-1/users-1.mongo.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines the MongoDB $jsonSchema for service `users1`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 //!code: imports //!end

--- a/test/authentication-1.test-expected/src1/services/users-1/users-1.mongoose.js
+++ b/test/authentication-1.test-expected/src1/services/users-1/users-1.mongoose.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines Mongoose model for service `users1`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 const mongoose = require('mongoose'); // eslint-disable-line no-unused-vars

--- a/test/authentication-2.test-expected/src1/models/nedb-1.model.js
+++ b/test/authentication-2.test-expected/src1/models/nedb-1.model.js
@@ -1,12 +1,26 @@
+
+// nedb1-model.js - An nedb model
 const NeDB = require('nedb');
 const path = require('path');
+//!code: nedb_imports //!end
+//!code: nedb_init //!end
 
-module.exports = function (app) {
+let moduleExports = function (app) {
   const dbPath = app.get('nedb');
-  const Model = new NeDB({
+  //!<DEFAULT> code: nedb_client
+  let Model = new NeDB({
     filename: path.join(dbPath, 'nedb-1.db'),
     autoload: true
   });
+  //!end
 
+  //!code: nedb_func_return //!end
   return Model;
 };
+//!code: nedb_more //!end
+
+//!code: nedb_exports //!end
+module.exports = moduleExports;
+
+//!code: nedb_funcs //!end
+//!code: nedb_end //!end

--- a/test/authentication-2.test-expected/src1/models/users-1.model.js
+++ b/test/authentication-2.test-expected/src1/models/users-1.model.js
@@ -1,14 +1,27 @@
+
+// users1-model.js - An nedb model for user entity
 const NeDB = require('nedb');
 const path = require('path');
+//!code: nedb_imports //!end
+//!code: nedb_init //!end
 
-module.exports = function (app) {
+let moduleExports = function (app) {
   const dbPath = app.get('nedb');
-  const Model = new NeDB({
+  //!<DEFAULT> code: nedb_client
+  let Model = new NeDB({
     filename: path.join(dbPath, 'users-1.db'),
     autoload: true
   });
-
   Model.ensureIndex({ fieldName: 'email', unique: true });
+  //!end
 
+  //!code: nedb_func_return //!end
   return Model;
 };
+//!code: nedb_more //!end
+
+//!code: nedb_exports //!end
+module.exports = moduleExports;
+
+//!code: nedb_funcs //!end
+//!code: nedb_end //!end

--- a/test/authentication-2.test-expected/src1/services/nedb-1/nedb-1.mongo.js
+++ b/test/authentication-2.test-expected/src1/services/nedb-1/nedb-1.mongo.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines the MongoDB $jsonSchema for service `nedb1`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 //!code: imports //!end

--- a/test/authentication-2.test-expected/src1/services/nedb-1/nedb-1.mongoose.js
+++ b/test/authentication-2.test-expected/src1/services/nedb-1/nedb-1.mongoose.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines Mongoose model for service `nedb1`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 const mongoose = require('mongoose'); // eslint-disable-line no-unused-vars

--- a/test/authentication-2.test-expected/src1/services/users-1/users-1.mongo.js
+++ b/test/authentication-2.test-expected/src1/services/users-1/users-1.mongo.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines the MongoDB $jsonSchema for service `users1`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 //!code: imports //!end

--- a/test/authentication-2.test-expected/src1/services/users-1/users-1.mongoose.js
+++ b/test/authentication-2.test-expected/src1/services/users-1/users-1.mongoose.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines Mongoose model for service `users1`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 const mongoose = require('mongoose'); // eslint-disable-line no-unused-vars

--- a/test/authentication-3.test-expected/src1/models/nedb-1.model.js
+++ b/test/authentication-3.test-expected/src1/models/nedb-1.model.js
@@ -1,12 +1,26 @@
+
+// nedb1-model.js - An nedb model
 const NeDB = require('nedb');
 const path = require('path');
+//!code: nedb_imports //!end
+//!code: nedb_init //!end
 
-module.exports = function (app) {
+let moduleExports = function (app) {
   const dbPath = app.get('nedb');
-  const Model = new NeDB({
+  //!<DEFAULT> code: nedb_client
+  let Model = new NeDB({
     filename: path.join(dbPath, 'nedb-1.db'),
     autoload: true
   });
+  //!end
 
+  //!code: nedb_func_return //!end
   return Model;
 };
+//!code: nedb_more //!end
+
+//!code: nedb_exports //!end
+module.exports = moduleExports;
+
+//!code: nedb_funcs //!end
+//!code: nedb_end //!end

--- a/test/authentication-3.test-expected/src1/models/nedb-2.model.js
+++ b/test/authentication-3.test-expected/src1/models/nedb-2.model.js
@@ -1,12 +1,26 @@
+
+// nedb2-model.js - An nedb model
 const NeDB = require('nedb');
 const path = require('path');
+//!code: nedb_imports //!end
+//!code: nedb_init //!end
 
-module.exports = function (app) {
+let moduleExports = function (app) {
   const dbPath = app.get('nedb');
-  const Model = new NeDB({
+  //!<DEFAULT> code: nedb_client
+  let Model = new NeDB({
     filename: path.join(dbPath, 'nedb-2.db'),
     autoload: true
   });
+  //!end
 
+  //!code: nedb_func_return //!end
   return Model;
 };
+//!code: nedb_more //!end
+
+//!code: nedb_exports //!end
+module.exports = moduleExports;
+
+//!code: nedb_funcs //!end
+//!code: nedb_end //!end

--- a/test/authentication-3.test-expected/src1/models/users-1.model.js
+++ b/test/authentication-3.test-expected/src1/models/users-1.model.js
@@ -1,14 +1,27 @@
+
+// users1-model.js - An nedb model for user entity
 const NeDB = require('nedb');
 const path = require('path');
+//!code: nedb_imports //!end
+//!code: nedb_init //!end
 
-module.exports = function (app) {
+let moduleExports = function (app) {
   const dbPath = app.get('nedb');
-  const Model = new NeDB({
+  //!<DEFAULT> code: nedb_client
+  let Model = new NeDB({
     filename: path.join(dbPath, 'users-1.db'),
     autoload: true
   });
-
   Model.ensureIndex({ fieldName: 'email', unique: true });
+  //!end
 
+  //!code: nedb_func_return //!end
   return Model;
 };
+//!code: nedb_more //!end
+
+//!code: nedb_exports //!end
+module.exports = moduleExports;
+
+//!code: nedb_funcs //!end
+//!code: nedb_end //!end

--- a/test/authentication-3.test-expected/src1/services/nedb-1/nedb-1.mongo.js
+++ b/test/authentication-3.test-expected/src1/services/nedb-1/nedb-1.mongo.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines the MongoDB $jsonSchema for service `nedb1`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 //!code: imports //!end

--- a/test/authentication-3.test-expected/src1/services/nedb-1/nedb-1.mongoose.js
+++ b/test/authentication-3.test-expected/src1/services/nedb-1/nedb-1.mongoose.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines Mongoose model for service `nedb1`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 const mongoose = require('mongoose'); // eslint-disable-line no-unused-vars

--- a/test/authentication-3.test-expected/src1/services/nedb-2/nedb-2.mongo.js
+++ b/test/authentication-3.test-expected/src1/services/nedb-2/nedb-2.mongo.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines the MongoDB $jsonSchema for service `nedb2`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 //!code: imports //!end

--- a/test/authentication-3.test-expected/src1/services/nedb-2/nedb-2.mongoose.js
+++ b/test/authentication-3.test-expected/src1/services/nedb-2/nedb-2.mongoose.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines Mongoose model for service `nedb2`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 const mongoose = require('mongoose'); // eslint-disable-line no-unused-vars

--- a/test/authentication-3.test-expected/src1/services/users-1/users-1.mongo.js
+++ b/test/authentication-3.test-expected/src1/services/users-1/users-1.mongo.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines the MongoDB $jsonSchema for service `users1`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 //!code: imports //!end

--- a/test/authentication-3.test-expected/src1/services/users-1/users-1.mongoose.js
+++ b/test/authentication-3.test-expected/src1/services/users-1/users-1.mongoose.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines Mongoose model for service `users1`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 const mongoose = require('mongoose'); // eslint-disable-line no-unused-vars

--- a/test/graphql.test-expected/src1/models/nedb-1.model.js
+++ b/test/graphql.test-expected/src1/models/nedb-1.model.js
@@ -1,12 +1,26 @@
+
+// nedb1-model.js - An nedb model
 const NeDB = require('nedb');
 const path = require('path');
+//!code: nedb_imports //!end
+//!code: nedb_init //!end
 
-module.exports = function (app) {
+let moduleExports = function (app) {
   const dbPath = app.get('nedb');
-  const Model = new NeDB({
+  //!<DEFAULT> code: nedb_client
+  let Model = new NeDB({
     filename: path.join(dbPath, 'nedb-1.db'),
     autoload: true
   });
+  //!end
 
+  //!code: nedb_func_return //!end
   return Model;
 };
+//!code: nedb_more //!end
+
+//!code: nedb_exports //!end
+module.exports = moduleExports;
+
+//!code: nedb_funcs //!end
+//!code: nedb_end //!end

--- a/test/graphql.test-expected/src1/models/nedb-2.model.js
+++ b/test/graphql.test-expected/src1/models/nedb-2.model.js
@@ -1,12 +1,26 @@
+
+// nedb2-model.js - An nedb model
 const NeDB = require('nedb');
 const path = require('path');
+//!code: nedb_imports //!end
+//!code: nedb_init //!end
 
-module.exports = function (app) {
+let moduleExports = function (app) {
   const dbPath = app.get('nedb');
-  const Model = new NeDB({
+  //!<DEFAULT> code: nedb_client
+  let Model = new NeDB({
     filename: path.join(dbPath, 'nedb-2.db'),
     autoload: true
   });
+  //!end
 
+  //!code: nedb_func_return //!end
   return Model;
 };
+//!code: nedb_more //!end
+
+//!code: nedb_exports //!end
+module.exports = moduleExports;
+
+//!code: nedb_funcs //!end
+//!code: nedb_end //!end

--- a/test/graphql.test-expected/src1/services/nedb-1/nedb-1.mongo.js
+++ b/test/graphql.test-expected/src1/services/nedb-1/nedb-1.mongo.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines the MongoDB $jsonSchema for service `nedb1`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 //!code: imports //!end

--- a/test/graphql.test-expected/src1/services/nedb-1/nedb-1.mongoose.js
+++ b/test/graphql.test-expected/src1/services/nedb-1/nedb-1.mongoose.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines Mongoose model for service `nedb1`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 const mongoose = require('mongoose'); // eslint-disable-line no-unused-vars

--- a/test/graphql.test-expected/src1/services/nedb-2/nedb-2.mongo.js
+++ b/test/graphql.test-expected/src1/services/nedb-2/nedb-2.mongo.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines the MongoDB $jsonSchema for service `nedb2`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 //!code: imports //!end

--- a/test/graphql.test-expected/src1/services/nedb-2/nedb-2.mongoose.js
+++ b/test/graphql.test-expected/src1/services/nedb-2/nedb-2.mongoose.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines Mongoose model for service `nedb2`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 const mongoose = require('mongoose'); // eslint-disable-line no-unused-vars

--- a/test/middleware.test-expected/src1/models/nedb-1.model.js
+++ b/test/middleware.test-expected/src1/models/nedb-1.model.js
@@ -1,12 +1,26 @@
+
+// nedb1-model.js - An nedb model
 const NeDB = require('nedb');
 const path = require('path');
+//!code: nedb_imports //!end
+//!code: nedb_init //!end
 
-module.exports = function (app) {
+let moduleExports = function (app) {
   const dbPath = app.get('nedb');
-  const Model = new NeDB({
+  //!<DEFAULT> code: nedb_client
+  let Model = new NeDB({
     filename: path.join(dbPath, 'nedb-1.db'),
     autoload: true
   });
+  //!end
 
+  //!code: nedb_func_return //!end
   return Model;
 };
+//!code: nedb_more //!end
+
+//!code: nedb_exports //!end
+module.exports = moduleExports;
+
+//!code: nedb_funcs //!end
+//!code: nedb_end //!end

--- a/test/middleware.test-expected/src1/models/nedb-2.model.js
+++ b/test/middleware.test-expected/src1/models/nedb-2.model.js
@@ -1,12 +1,26 @@
+
+// nedb2-model.js - An nedb model
 const NeDB = require('nedb');
 const path = require('path');
+//!code: nedb_imports //!end
+//!code: nedb_init //!end
 
-module.exports = function (app) {
+let moduleExports = function (app) {
   const dbPath = app.get('nedb');
-  const Model = new NeDB({
+  //!<DEFAULT> code: nedb_client
+  let Model = new NeDB({
     filename: path.join(dbPath, 'nedb-2.db'),
     autoload: true
   });
+  //!end
 
+  //!code: nedb_func_return //!end
   return Model;
 };
+//!code: nedb_more //!end
+
+//!code: nedb_exports //!end
+module.exports = moduleExports;
+
+//!code: nedb_funcs //!end
+//!code: nedb_end //!end

--- a/test/middleware.test-expected/src1/services/nedb-1/nedb-1.mongo.js
+++ b/test/middleware.test-expected/src1/services/nedb-1/nedb-1.mongo.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines the MongoDB $jsonSchema for service `nedb1`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 //!code: imports //!end

--- a/test/middleware.test-expected/src1/services/nedb-1/nedb-1.mongoose.js
+++ b/test/middleware.test-expected/src1/services/nedb-1/nedb-1.mongoose.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines Mongoose model for service `nedb1`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 const mongoose = require('mongoose'); // eslint-disable-line no-unused-vars

--- a/test/middleware.test-expected/src1/services/nedb-2/nedb-2.mongo.js
+++ b/test/middleware.test-expected/src1/services/nedb-2/nedb-2.mongo.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines the MongoDB $jsonSchema for service `nedb2`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 //!code: imports //!end

--- a/test/middleware.test-expected/src1/services/nedb-2/nedb-2.mongoose.js
+++ b/test/middleware.test-expected/src1/services/nedb-2/nedb-2.mongoose.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines Mongoose model for service `nedb2`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 const mongoose = require('mongoose'); // eslint-disable-line no-unused-vars

--- a/test/service.test-expected/src1/models/nedb-1.model.js
+++ b/test/service.test-expected/src1/models/nedb-1.model.js
@@ -1,12 +1,26 @@
+
+// nedb1-model.js - An nedb model
 const NeDB = require('nedb');
 const path = require('path');
+//!code: nedb_imports //!end
+//!code: nedb_init //!end
 
-module.exports = function (app) {
+let moduleExports = function (app) {
   const dbPath = app.get('nedb');
-  const Model = new NeDB({
+  //!<DEFAULT> code: nedb_client
+  let Model = new NeDB({
     filename: path.join(dbPath, 'nedb-1.db'),
     autoload: true
   });
+  //!end
 
+  //!code: nedb_func_return //!end
   return Model;
 };
+//!code: nedb_more //!end
+
+//!code: nedb_exports //!end
+module.exports = moduleExports;
+
+//!code: nedb_funcs //!end
+//!code: nedb_end //!end

--- a/test/service.test-expected/src1/models/nedb-2.model.js
+++ b/test/service.test-expected/src1/models/nedb-2.model.js
@@ -1,12 +1,26 @@
+
+// nedb2-model.js - An nedb model
 const NeDB = require('nedb');
 const path = require('path');
+//!code: nedb_imports //!end
+//!code: nedb_init //!end
 
-module.exports = function (app) {
+let moduleExports = function (app) {
   const dbPath = app.get('nedb');
-  const Model = new NeDB({
+  //!<DEFAULT> code: nedb_client
+  let Model = new NeDB({
     filename: path.join(dbPath, 'nedb-2.db'),
     autoload: true
   });
+  //!end
 
+  //!code: nedb_func_return //!end
   return Model;
 };
+//!code: nedb_more //!end
+
+//!code: nedb_exports //!end
+module.exports = moduleExports;
+
+//!code: nedb_funcs //!end
+//!code: nedb_end //!end

--- a/test/service.test-expected/src1/services/nedb-1/nedb-1.mongo.js
+++ b/test/service.test-expected/src1/services/nedb-1/nedb-1.mongo.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines the MongoDB $jsonSchema for service `nedb1`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 //!code: imports //!end

--- a/test/service.test-expected/src1/services/nedb-1/nedb-1.mongoose.js
+++ b/test/service.test-expected/src1/services/nedb-1/nedb-1.mongoose.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines Mongoose model for service `nedb1`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 const mongoose = require('mongoose'); // eslint-disable-line no-unused-vars

--- a/test/service.test-expected/src1/services/nedb-2/nedb-2.mongo.js
+++ b/test/service.test-expected/src1/services/nedb-2/nedb-2.mongo.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines the MongoDB $jsonSchema for service `nedb2`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 //!code: imports //!end

--- a/test/service.test-expected/src1/services/nedb-2/nedb-2.mongoose.js
+++ b/test/service.test-expected/src1/services/nedb-2/nedb-2.mongoose.js
@@ -1,4 +1,5 @@
 
+/* eslint quotes: 0 */
 // Defines Mongoose model for service `nedb2`. (Can be re-generated.)
 const deepMerge = require('deepmerge');
 const mongoose = require('mongoose'); // eslint-disable-line no-unused-vars


### PR DESCRIPTION
- Default type fixed on first properties prop in name.schema.js.
  Problem involved recursion on nested objects.
- Upgraded the various name.model.js templates.
  - Non-user-entity templates have standard insertion points.
  - User-entity templates for NeDB and Monoose have them too.
  - Mongoose model 'require's and uses name.mongoose.js schema.
  - Sequelize, Knex non-user-entity templates have standard insertion
    points. Waiting for a tester to do more.
  - Sequelize, Knex user-entity templates unchanged. Waiting on a tester.
- Updated generator tests for new NeDB templates
