### PR TITLE
Upgraded generated BatchLoader resolvers for pagination.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -93,6 +93,20 @@ NO   --> Let user handle this as we think object keys will be rarely used.
 LATER - findUser & findPost produce with batchloader "null" found at char 681 near: "followed_by": null, "followi
 LATER   graphql/lib/run-time/feathers/extract-items.js#extractAllItems : return [] instead of null x2.
 
+- Add deepmerge as a dependency on 'generate service'
+- mongodb requires `new ObjectID(foreign_key)`
+- cannot deepmerge mongo BSON instances
+
+- batchloaders need context.params.paginate = false
+- batchloaders meed maximum loads & set equal to default.json#pagination.max
+- add to batchloader docs that pagination affects $in, so pagination=false needed.
+- batchloaders return null rather than []
+
+
+- why are there blank lines on loading deps between 'skip' and 'force' ?
+- check @f+/graphql is installed on `generate graphql`
+  There may be problems finding graphql/graphql in cli-generator-example
+
 - GraphQL pagination. (a) in-record fields (b) {total, skip, limit, data} (c) separate pagination object.
   Maybe specify which resolvers we want to support pagination.
 - should paginate values in default.json be app level options?
@@ -101,4 +115,20 @@ LATER   graphql/lib/run-time/feathers/extract-items.js#extractAllItems : return 
 - create Sequelize schema
 - create fastJoin definitions
 - create for swagger
- 
+
+Upgraded generated BatchLoader resolvers for pagination.
+
+- @f+/graphql@1.5.0 is the required dependency for generated apps.
+  This should be installed when a *new* app is generated.
+  PLEASE INFORM IF ITS UPDATED automatically on `generate graphql`.
+  (Not that there's much we can do about it.) 
+- graphql/graphql remains a package.json dependency of @f+/graphql
+- In batchloaders.resolvers.js, the BatchLoader func will be called with
+  no more than `maxBatchSize` keys. maxBatchSize defaults to
+  default.json#paginate.max.
+- maxBatchSize can be customized. undefined or Infinity will call with all
+  keys, as it did previously.
+- `paginate: false` is the default for BatchLoaders, so maxBatchSize
+  controls the pagination.
+- BatchLoaders now return `[]` instead of `null` for an array of results
+  containing no records.

--- a/generators/writing/index.js
+++ b/generators/writing/index.js
@@ -448,6 +448,7 @@ module.exports = function generatorWriting (generator, what) {
 
     // Generate modules
     generatorFs(generator, context, todos);
+
     // Update dependencies
     generator._packagerInstall([
       '@feathers-plus/graphql', // has graphql/graphql as a dependency

--- a/generators/writing/templates/src/services/graphql/batchloader.resolvers.ejs
+++ b/generators/writing/templates/src/services/graphql/batchloader.resolvers.ejs
@@ -9,6 +9,11 @@ let moduleExports = function batchLoaderResolvers(app, options) {
   // eslint-disable-next-line
   let { convertArgsToParams, convertArgsToFeathers, extractAllItems, extractFirstItem,
     feathersBatchLoader: { feathersBatchLoader } } = options;
+  <%- insertFragment('max-batch-size', [
+    '  let defaultPaginate = app.get(\'paginate\');',
+    '  let maxBatchSize = defaultPaginate && typeof defaultPaginate.max === \'number\' ?',
+    '    defaultPaginate.max : undefined;',
+  ]) %>
 
 <% let __temp = Object.keys(mapping.feathers).map(serviceName =>
   `  let ${serviceName} = app.service('${mapping.feathers[serviceName].path}');`
@@ -17,8 +22,8 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
   <%- insertFragment('get-result', [
     '  // Given a fieldName in the parent record, return the result from a BatchLoader',
-    '  // The result will be an object, an array of objects, or null.',
-    '  function getResult(batchLoaderName, fieldName) {',
+    '  // The result will be an object (or null), or an array of objects (possibly empty).',
+    '  function getResult(batchLoaderName, fieldName, isArray) {',
     '    const contentByDot = `batchLoaders.${batchLoaderName}`;',
     '',
     '    // `content.app = app` is the Feathers app object.',
@@ -31,10 +36,13 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     '        setByDot(content, contentByDot, batchLoader);',
     '      }',
     '',
-    '      return batchLoader.load(parent[fieldName]);',
+    '      const returns = batchLoader.load(parent[fieldName]);',
+    '      return !isArray ? returns : returns.then(result => result || []);',
     '    };',
     '  }',
   ]) %>
+<%# -%>
+<%# === BatchLoaders =========================================================================== -%>
 
   // A transient BatchLoader can be created only when (one of) its resolver has been called,
   // as the BatchLoader loading function may require data from the 'args' passed to the resolver.
@@ -77,11 +85,13 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     `    case '${graphqlName}.${fieldName}':`,
     `      return feathersBatchLoader(dataLoaderName, '${__code}', '${__addField.relation.otherTable}',`,
     '        keys => {',
-    '          feathersParams = convertArgsToFeathers(args,',
-    `            { query: { ${__addField.relation.otherTable}: { $in: keys }, $sort: undefined }, populate: false }`,
-    '          );',
+    '          feathersParams = convertArgsToFeathers(args, {',
+    `            query: { ${__addField.relation.otherTable}: { $in: keys }, $sort: undefined },`,
+    '            _populate: \'skip\', paginate: false',
+    '          });',
     `          return ${__addField.serviceName}.find(feathersParams);`,
-    '        }',
+    '        },',
+    '        maxBatchSize // Max #keys in a BatchLoader func call.',
     '      );',
   ];
 -%>
@@ -102,6 +112,8 @@ let moduleExports = function batchLoaderResolvers(app, options) {
       ]) %>
     }
   }
+<%# -%>
+<%# === resolvers ============================================================================== -%>
 
   let returns = {
 <%# -%>
@@ -123,7 +135,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 <%# --- if/else-1 starts below. -%>
 <% if (__addField.serviceName) {
   __temp = [
-    `      ${fieldName}: getResult('${graphqlName}.${fieldName}', '${__addField.relation.ourTable}'),`,
+    `      ${fieldName}: getResult('${graphqlName}.${fieldName}', '${__addField.relation.ourTable}'${__addField.isArray ? ', true' : ''}),`,
   ];
 -%>
       <%- insertFragment(`resolver-${graphqlName}-${fieldName}`, __temp) %>
@@ -140,7 +152,8 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 <%# --- forEach-1 ends above. -%>
 
     <%- insertFragment('resolver_field_more') %>
-
+<%# -%>
+<%# === Query resolvers ======================================================================== -%>
     Query: {
 <%# -%>
 <%# --- forEach-3 starts below. Loop thru the schemas of GraphQL enabled services. -%>


### PR DESCRIPTION
- @f+/graphql@1.5.0 is the required dependency for generated apps.
  This should be installed when a *new* app is generated.
  PLEASE INFORM IF ITS UPDATED automatically on `generate graphql`.
  (Not that there's much we can do about it.)
- graphql/graphql remains a package.json dependency of @f+/graphql
- In batchloaders.resolvers.js, the BatchLoader func will be called with
  no more than `maxBatchSize` keys. maxBatchSize defaults to
  default.json#paginate.max.
- maxBatchSize can be customized. undefined or Infinity will call with all
  keys, as it did previously.
- `paginate: false` is the default for BatchLoaders, so maxBatchSize
  controls the pagination.
- BatchLoaders now return `[]` instead of `null` for an array of results
  containing no records.
