### PR TITLE
- additionalProperties is now copied from name.schema.js,

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -108,7 +108,7 @@ LATER   graphql/lib/run-time/feathers/extract-items.js#extractAllItems : return 
 - add to batchloader docs that pagination affects $in, so pagination=false needed.
 - Matt: Just fwiw when I do an npm i it removed the git ref’d feathers-hooks-common
   Point out how batchloader can control max keys in a call.
-- why are there blank lines on loading deps between 'skip' and 'force' ?
+- why are there blank lines on loading deps between 'skip' and 'force' ? generate service
 - Let's say we had mongodb services and changed them to NeDB. commentions['mongodb+mongodb'] will
   remain. This causes, for example, src/mongodb.js to still be generated.
   Basically, the generator does not remove info in specs that's no longer relavent.

--- a/generators/writing/templates/src/services/_types/mongodb.ejs
+++ b/generators/writing/templates/src/services/_types/mongodb.ejs
@@ -2,7 +2,9 @@
 // Initializes the `<%= serviceName %>` service on path `/<%= path %>`
 const createService = require('feathers-mongodb');
 const hooks = require('./<%= kebabName %>.hooks');
-<%- insertFragment('mongo_imports') %>
+<%- insertFragment('mongo_imports', [
+  'let $jsonSchema = require(\'./${kebabName}.mongo\');'
+]) %>
 <%- insertFragment('mongo_init') %>
 
 let moduleExports = function (app) {
@@ -19,7 +21,9 @@ let moduleExports = function (app) {
 
   mongoClient.then(db => {
     return db.createCollection('<%= kebabName %>', {
-      // validator: { $jsonSchema: validateSchema }
+      <%- insertFragment('mongo_create_collection', [
+        'validator: { $jsonSchema: $jsonSchema }',
+      ]) %>
     });
   })
     .then(serviceModel => {

--- a/generators/writing/templates/src/services/name/name.validate.ejs
+++ b/generators/writing/templates/src/services/name/name.validate.ejs
@@ -1,7 +1,7 @@
 
 /* eslint quotes: 0 */
 // Validation definitions for validateSchema hook for service `<%= serviceName %>`. (Can be re-generated.)
-const { validateSchema } = require('@feathers-plus/feathers-hooks-common');
+const { validateSchema } = require('feathers-hooks-common');
 const deepMerge = require('deepmerge');
 const ajv = require('ajv');
 <%- insertFragment('imports') %>

--- a/lib/service-specs-to-mongo-json-schema.js
+++ b/lib/service-specs-to-mongo-json-schema.js
@@ -1,12 +1,17 @@
 
-const discardFields = ['id', '_id'];
+const discardFields = ['id'];
 
 module.exports = function serviceSpecsToMongoJsonSchema (feathersSpec, feathersExtension, depth = 1) {
+  const required = feathersSpec.required || [];
   const properties = feathersSpec.properties || {};
-  const mongoProperties = {};
+  const mongoProperties = {
+    _id: { // An _id property in name.schema.js can add properties to this
+      bsonType: 'objectId',
+    },
+  };
 
   const schemaTypesToMongo = {
-    ID: 'string',
+    ID: 'objectId',
     integer: 'int',
   };
 
@@ -22,21 +27,16 @@ module.exports = function serviceSpecsToMongoJsonSchema (feathersSpec, feathersE
         mongoProperty = mongoProperties[name];
         break;
       default:
-        mongoProperty = mongoProperties[name] = Object({}, property);
+        mongoProperty = mongoProperties[name] = Object.assign({}, property);
         mongoProperty.bsonType = schemaTypesToMongo[property.type] || property.type;
         delete mongoProperty.type;
         break;
     }
-
-    /* Our Mongoose models contain no verification information
-    if (required.indexOf(name) !== -1 && property.type !== 'object') {
-      mongoProperty.required = true;
-    }
-    */
   });
 
   return {
     bsonType: 'object',
+    additionalProperties: feathersSpec.additionalProperties || false,
     required: feathersSpec.required,
     properties: mongoProperties
   };


### PR DESCRIPTION
- Separate docs/graphql-pagination.md had roadmap for returning
  pagination info for interior joins.
- docs/graphql.md now defines the new context.params.graphql =
  resolver path.
- Updated mongo's name.service.js to accommodate $jsonSchema.
- service.resolvers.js uses new format for convertArgsToFeathers.
- batchloader.resolvers.js uses new format for convertArgsToFeathers.
- name.mongo.js now uses mongo's 'int' instead of 'interger'.
- hopefully fixed extra blank in service.resolver.js `$sort: {  _id: 1 }'
