### PR TITLE
 Adds generator 'this' to serviceSpecsExpand call

### DIFF
--- a/generators/graphql/index.js
+++ b/generators/graphql/index.js
@@ -35,7 +35,7 @@ module.exports = class GraphqlGenerator extends Generator {
     this.log();
 
     const graphqlSpecs = specs.graphql;
-    const { mapping } = serviceSpecsExpand(specs);
+    const { mapping } = serviceSpecsExpand(specs, this);
 
     if (!Object.keys(mapping.feathers).length) {
       this.log('No services are configured as being served by GraphQL. ');


### PR DESCRIPTION
The serviceSpecsCombine function expects a generator object, passed down from serviceSpecsExpand(). In the graphql generator, the second parameter (generator or this) was not being sent down. This adds the generator in as the second parameter.

There are no open issues related to this. Fix seemed easy.

This is not dependent on any other repos.