### PR TITLE
Fix arrays of objects in Mongoose schemas

### DIFF
--- a/lib/service-specs-to-mongoose.js
+++ b/lib/service-specs-to-mongoose.js
@@ -89,7 +89,8 @@ module.exports = function serviceSpecsToMongoose (feathersSpec, feathersExtensio
       case 'array':
         items = Array.isArray(property.items) ? property.items : [property.items];
 
-        mongooseProperty.type = [typeEquivalence[items[0].type]];
+        const type = items[0].type
+        mongooseProperty.type = type === 'object' ? [] : [typeEquivalence[items[0].type]];
         if (items[0].enum) {
           mongooseProperty.enum = items[0].enum;
         }

--- a/test/helpers/users.schema-enum.js
+++ b/test/helpers/users.schema-enum.js
@@ -44,6 +44,14 @@ let schema = {
       }
     },
 
+    categories: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {}
+      }
+    },
+
     dept: { enum: [ 'acct' ] }
     // !end
   },

--- a/test/json-schema/marshall-app.test.js
+++ b/test/json-schema/marshall-app.test.js
@@ -2619,12 +2619,8 @@ const expectedMongooseSchema = {
       type: String,
       required: true
     },
-    phones: [
-      Object
-    ],
-    emails: [
-      Object
-    ],
+    phones: [],
+    emails: [],
     primaryContact: String,
     notes: String
   },
@@ -2790,9 +2786,7 @@ const expectedMongooseSchema = {
     primaryPhotoUrl: String,
     primaryPhotoCoordinates: String,
     primaryPhotoUploadInfo: String,
-    categories: [
-      Object
-    ],
+    categories: [],
     location: {
       type: {
         type: String,

--- a/test/service-specs-to-mongoose.test.js
+++ b/test/service-specs-to-mongoose.test.js
@@ -25,4 +25,8 @@ describe('Creates Mongoose Schemas', function () {
     assert.deepEqual(mongooseSchema.registerdDate.default, Date.now, 'registerdDate default value was correctly applied');
    
   });
+  it('properly generates model for array of objects', function () {
+    const mongooseSchema = serviceSpecsToMongoose(usersSchema.schema);
+    assert.deepEqual(mongooseSchema.categories, [], 'categories ')
+  });
 });


### PR DESCRIPTION
This fixes an issue for Mongoose schemas where arrays of objects have to be defined as `[ ]`, but the generator has been defining them as `[ Object ]`, so Mongoose has been throwing an error stating `Cast to [undefined] failed for value`.