### PR TITLE
Allow tests to run from Mac private folder

### DIFF
--- a/lib/specs.js
+++ b/lib/specs.js
@@ -80,7 +80,8 @@ async function setPath (generator1) {
     );
 
     // Test if test suite is running.
-    stashedSpecs._isRunningTests = generator.destinationRoot().substr(0, 5) === '/tmp/';
+    const root = generator.destinationRoot()
+    stashedSpecs._isRunningTests = root.startsWith('/private/') || root.startsWith('/tmp/');
 
     // Extract custom code
     await refreshCodeFragments(generator.destinationRoot());


### PR DESCRIPTION
Macs have a `/private` folder where the tests run, so this check had to be updated.