### PR TITLE
import and use App interface in src/index.ts

### DIFF
--- a/generators/writing/templates/src/index.ejs
+++ b/generators/writing/templates/src/index.ejs
@@ -10,6 +10,7 @@
 <%- tplImports('seedData', './seed-data') %>
 <% } -%>
 <%# --- if-1 ends above. -%>
+<%- tplTsOnly(`import { App } from './app.interface'${sc}${EOL}`) -%>
 <%- insertFragment('imports') %>
 <%- insertFragment('init') %>
 
@@ -32,7 +33,7 @@ server.on('listening', async () => {
 <%# -%>
 <%# --- if-2 starts below. -%>
 <% if (specs.app.seedData) { -%>
-  await seedData(app);
+  <%- tplJsOrTs('await seedData(app);', 'await seedData(app as App);') %>
 <% } -%>
 <%# --- if-2 ends above. -%>
   <%- insertFragment('listening1') %>


### PR DESCRIPTION
I'm using typescript mode and enable seed data option.

After generate authentication, VS Code will highlight "await seedData(app)" line and give this error message:
```
[ts]
Argument of type 'Application<object>' is not assignable to parameter of type 'Application<{ 'users': User; }>'.
  Type 'Application<object>' is not assignable to type 'Application<{ 'users': User; }>'.
```

By type casting the app variable with App interface, the error doesn't show up.