### PR TITLE
Revert "Typescript Fixes"

### DIFF
--- a/examples/js/02-app/feathers-app/src/app.js
+++ b/examples/js/02-app/feathers-app/src/app.js
@@ -12,7 +12,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/examples/js/03-authentication/feathers-app/src/app.js
+++ b/examples/js/03-authentication/feathers-app/src/app.js
@@ -12,7 +12,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/examples/js/04-model/feathers-app/src/app.js
+++ b/examples/js/04-model/feathers-app/src/app.js
@@ -12,7 +12,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/examples/js/05-secret/feathers-app/src/app.js
+++ b/examples/js/05-secret/feathers-app/src/app.js
@@ -12,7 +12,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/examples/js/06-service/feathers-app/src/app.js
+++ b/examples/js/06-service/feathers-app/src/app.js
@@ -12,7 +12,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/examples/js/07-fakes/feathers-app/src/app.js
+++ b/examples/js/07-fakes/feathers-app/src/app.js
@@ -12,7 +12,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/examples/js/09-graphql/feathers-app/src/app.js
+++ b/examples/js/09-graphql/feathers-app/src/app.js
@@ -12,7 +12,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/examples/js/09-graphql/feathers-app/src/services/graphql/batchloader.resolvers.js
+++ b/examples/js/09-graphql/feathers-app/src/services/graphql/batchloader.resolvers.js
@@ -55,83 +55,83 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Role.users: [User!]
+    // !<DEFAULT> code: bl-Role-users
+    case 'Role.users':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'roleId',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { roleId: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return users.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Team.members: [User!]
+    // !<DEFAULT> code: bl-Team-members
+    case 'Team.members':
+      return feathersBatchLoader(dataLoaderName, '[!]', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return users.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Role.users: [User!]
-      // !<DEFAULT> code: bl-Role-users
-      case 'Role.users':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'roleId',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { roleId: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return users.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
+    // User.role(query: JSON, params: JSON, key: JSON): Role
+    // !<DEFAULT> code: bl-User-role
+    case 'User.role':
+      return feathersBatchLoader(dataLoaderName, '', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return roles.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      // Team.members: [User!]
-      // !<DEFAULT> code: bl-Team-members
-      case 'Team.members':
-        return feathersBatchLoader(dataLoaderName, '[!]', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return users.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
+    // User.teams(query: JSON, params: JSON, key: JSON): [Team!]
+    // !<DEFAULT> code: bl-User-teams
+    case 'User.teams':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'memberIds',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { memberIds: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return teams.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      // User.role(query: JSON, params: JSON, key: JSON): Role
-      // !<DEFAULT> code: bl-User-role
-      case 'User.role':
-        return feathersBatchLoader(dataLoaderName, '', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return roles.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // User.teams(query: JSON, params: JSON, key: JSON): [Team!]
-      // !<DEFAULT> code: bl-User-teams
-      case 'User.teams':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'memberIds',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { memberIds: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return teams.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -184,7 +184,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findRole(query: JSON, params: JSON): [Role!]
       findRole(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { name: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return roles.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -198,7 +198,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findTeam(query: JSON, params: JSON): [Team!]
       findTeam(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { name: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return teams.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -212,7 +212,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findUser(query: JSON, params: JSON): [User!]
       findUser(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { lastName: 1, firstName: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   lastName: 1,   firstName: 1 } } });
         return users.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/examples/js/09-graphql/feathers-app/src/services/graphql/service.resolvers.js
+++ b/examples/js/09-graphql/feathers-app/src/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end

--- a/examples/js/10-hook/feathers-app/src/app.js
+++ b/examples/js/10-hook/feathers-app/src/app.js
@@ -12,7 +12,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/examples/js/10-hook/feathers-app/src/services/graphql/batchloader.resolvers.js
+++ b/examples/js/10-hook/feathers-app/src/services/graphql/batchloader.resolvers.js
@@ -55,83 +55,83 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Role.users: [User!]
+    // !<DEFAULT> code: bl-Role-users
+    case 'Role.users':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'roleId',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { roleId: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return users.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Team.members: [User!]
+    // !<DEFAULT> code: bl-Team-members
+    case 'Team.members':
+      return feathersBatchLoader(dataLoaderName, '[!]', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return users.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Role.users: [User!]
-      // !<DEFAULT> code: bl-Role-users
-      case 'Role.users':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'roleId',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { roleId: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return users.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
+    // User.role(query: JSON, params: JSON, key: JSON): Role
+    // !<DEFAULT> code: bl-User-role
+    case 'User.role':
+      return feathersBatchLoader(dataLoaderName, '', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return roles.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      // Team.members: [User!]
-      // !<DEFAULT> code: bl-Team-members
-      case 'Team.members':
-        return feathersBatchLoader(dataLoaderName, '[!]', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return users.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
+    // User.teams(query: JSON, params: JSON, key: JSON): [Team!]
+    // !<DEFAULT> code: bl-User-teams
+    case 'User.teams':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'memberIds',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { memberIds: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return teams.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      // User.role(query: JSON, params: JSON, key: JSON): Role
-      // !<DEFAULT> code: bl-User-role
-      case 'User.role':
-        return feathersBatchLoader(dataLoaderName, '', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return roles.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // User.teams(query: JSON, params: JSON, key: JSON): [Team!]
-      // !<DEFAULT> code: bl-User-teams
-      case 'User.teams':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'memberIds',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { memberIds: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return teams.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -184,7 +184,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findRole(query: JSON, params: JSON): [Role!]
       findRole(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { name: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return roles.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -198,7 +198,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findTeam(query: JSON, params: JSON): [Team!]
       findTeam(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { name: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return teams.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -212,7 +212,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findUser(query: JSON, params: JSON): [User!]
       findUser(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { lastName: 1, firstName: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   lastName: 1,   firstName: 1 } } });
         return users.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/examples/js/10-hook/feathers-app/src/services/graphql/service.resolvers.js
+++ b/examples/js/10-hook/feathers-app/src/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end

--- a/examples/js/11-test/feathers-app/src/app.js
+++ b/examples/js/11-test/feathers-app/src/app.js
@@ -12,7 +12,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/examples/js/11-test/feathers-app/src/services/graphql/batchloader.resolvers.js
+++ b/examples/js/11-test/feathers-app/src/services/graphql/batchloader.resolvers.js
@@ -55,83 +55,83 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Role.users: [User!]
+    // !<DEFAULT> code: bl-Role-users
+    case 'Role.users':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'roleId',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { roleId: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return users.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Team.members: [User!]
+    // !<DEFAULT> code: bl-Team-members
+    case 'Team.members':
+      return feathersBatchLoader(dataLoaderName, '[!]', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return users.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Role.users: [User!]
-      // !<DEFAULT> code: bl-Role-users
-      case 'Role.users':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'roleId',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { roleId: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return users.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
+    // User.role(query: JSON, params: JSON, key: JSON): Role
+    // !<DEFAULT> code: bl-User-role
+    case 'User.role':
+      return feathersBatchLoader(dataLoaderName, '', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return roles.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      // Team.members: [User!]
-      // !<DEFAULT> code: bl-Team-members
-      case 'Team.members':
-        return feathersBatchLoader(dataLoaderName, '[!]', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return users.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
+    // User.teams(query: JSON, params: JSON, key: JSON): [Team!]
+    // !<DEFAULT> code: bl-User-teams
+    case 'User.teams':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'memberIds',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { memberIds: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return teams.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      // User.role(query: JSON, params: JSON, key: JSON): Role
-      // !<DEFAULT> code: bl-User-role
-      case 'User.role':
-        return feathersBatchLoader(dataLoaderName, '', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return roles.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // User.teams(query: JSON, params: JSON, key: JSON): [Team!]
-      // !<DEFAULT> code: bl-User-teams
-      case 'User.teams':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'memberIds',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { memberIds: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return teams.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -184,7 +184,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findRole(query: JSON, params: JSON): [Role!]
       findRole(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { name: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return roles.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -198,7 +198,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findTeam(query: JSON, params: JSON): [Team!]
       findTeam(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { name: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return teams.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -212,7 +212,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findUser(query: JSON, params: JSON): [User!]
       findUser(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { lastName: 1, firstName: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   lastName: 1,   firstName: 1 } } });
         return users.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/examples/js/11-test/feathers-app/src/services/graphql/service.resolvers.js
+++ b/examples/js/11-test/feathers-app/src/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end

--- a/examples/js/12-test-examples/feathers-app/src/app.js
+++ b/examples/js/12-test-examples/feathers-app/src/app.js
@@ -12,7 +12,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/examples/js/12-test-examples/feathers-app/src/services/graphql/batchloader.resolvers.js
+++ b/examples/js/12-test-examples/feathers-app/src/services/graphql/batchloader.resolvers.js
@@ -55,83 +55,83 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Role.users: [User!]
+    // !<DEFAULT> code: bl-Role-users
+    case 'Role.users':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'roleId',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { roleId: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return users.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Team.members: [User!]
+    // !<DEFAULT> code: bl-Team-members
+    case 'Team.members':
+      return feathersBatchLoader(dataLoaderName, '[!]', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return users.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Role.users: [User!]
-      // !<DEFAULT> code: bl-Role-users
-      case 'Role.users':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'roleId',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { roleId: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return users.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
+    // User.role(query: JSON, params: JSON, key: JSON): Role
+    // !<DEFAULT> code: bl-User-role
+    case 'User.role':
+      return feathersBatchLoader(dataLoaderName, '', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return roles.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      // Team.members: [User!]
-      // !<DEFAULT> code: bl-Team-members
-      case 'Team.members':
-        return feathersBatchLoader(dataLoaderName, '[!]', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return users.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
+    // User.teams(query: JSON, params: JSON, key: JSON): [Team!]
+    // !<DEFAULT> code: bl-User-teams
+    case 'User.teams':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'memberIds',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { memberIds: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return teams.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      // User.role(query: JSON, params: JSON, key: JSON): Role
-      // !<DEFAULT> code: bl-User-role
-      case 'User.role':
-        return feathersBatchLoader(dataLoaderName, '', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return roles.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // User.teams(query: JSON, params: JSON, key: JSON): [Team!]
-      // !<DEFAULT> code: bl-User-teams
-      case 'User.teams':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'memberIds',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { memberIds: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return teams.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -184,7 +184,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findRole(query: JSON, params: JSON): [Role!]
       findRole(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { name: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return roles.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -198,7 +198,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findTeam(query: JSON, params: JSON): [Team!]
       findTeam(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { name: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return teams.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -212,7 +212,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findUser(query: JSON, params: JSON): [User!]
       findUser(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { lastName: 1, firstName: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   lastName: 1,   firstName: 1 } } });
         return users.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/examples/js/12-test-examples/feathers-app/src/services/graphql/service.resolvers.js
+++ b/examples/js/12-test-examples/feathers-app/src/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end

--- a/examples/ts/02-app/feathers-app/src/app.interface.ts
+++ b/examples/ts/02-app/feathers-app/src/app.interface.ts
@@ -16,11 +16,8 @@ import { Application } from '@feathersjs/express';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
+export type App = Application<{
   // !code: moduleExports // !end
-}
-
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/examples/ts/02-app/feathers-app/src/app.ts
+++ b/examples/ts/02-app/feathers-app/src/app.ts
@@ -9,10 +9,9 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
-import { Services } from './app.interface';
 import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
@@ -23,7 +22,7 @@ const generatorSpecs = require('../feathers-gen-specs.json');
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/examples/ts/03-authentication/feathers-app/src/app.interface.ts
+++ b/examples/ts/03-authentication/feathers-app/src/app.interface.ts
@@ -17,12 +17,9 @@ import { User } from './services/users/users.interface';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
-  'users': User;
+export type App = Application<{
+  'users': User,
   // !code: moduleExports // !end
-}
-
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/examples/ts/03-authentication/feathers-app/src/app.ts
+++ b/examples/ts/03-authentication/feathers-app/src/app.ts
@@ -9,10 +9,9 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
-import { Services } from './app.interface';
 import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
@@ -25,7 +24,7 @@ import mongoose from './mongoose';
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/examples/ts/04-model/feathers-app/src/app.interface.ts
+++ b/examples/ts/04-model/feathers-app/src/app.interface.ts
@@ -17,12 +17,9 @@ import { User } from './services/users/users.interface';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
-  'users': User;
+export type App = Application<{
+  'users': User,
   // !code: moduleExports // !end
-}
-
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/examples/ts/04-model/feathers-app/src/app.ts
+++ b/examples/ts/04-model/feathers-app/src/app.ts
@@ -9,10 +9,9 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
-import { Services } from './app.interface';
 import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
@@ -25,7 +24,7 @@ import mongoose from './mongoose';
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/examples/ts/05-secret/feathers-app/src/app.interface.ts
+++ b/examples/ts/05-secret/feathers-app/src/app.interface.ts
@@ -17,12 +17,9 @@ import { User } from './services/users/users.interface';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
-  'users': User;
+export type App = Application<{
+  'users': User,
   // !code: moduleExports // !end
-}
-
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/examples/ts/05-secret/feathers-app/src/app.ts
+++ b/examples/ts/05-secret/feathers-app/src/app.ts
@@ -9,10 +9,9 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
-import { Services } from './app.interface';
 import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
@@ -25,7 +24,7 @@ import mongoose from './mongoose';
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/examples/ts/06-service/feathers-app/src/app.interface.ts
+++ b/examples/ts/06-service/feathers-app/src/app.interface.ts
@@ -19,14 +19,11 @@ import { User } from './services/users/users.interface';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
-  'roles': Role;
-  'teams': Team;
-  'users': User;
+export type App = Application<{
+  'roles': Role,
+  'teams': Team,
+  'users': User,
   // !code: moduleExports // !end
-}
-
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/examples/ts/06-service/feathers-app/src/app.ts
+++ b/examples/ts/06-service/feathers-app/src/app.ts
@@ -9,7 +9,7 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
 import middleware from './middleware';
@@ -24,7 +24,7 @@ import mongoose from './mongoose';
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/examples/ts/07-fakes/feathers-app/src/app.interface.ts
+++ b/examples/ts/07-fakes/feathers-app/src/app.interface.ts
@@ -19,14 +19,11 @@ import { User } from './services/users/users.interface';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
-  'roles': Role;
-  'teams': Team;
-  'users': User;
+export type App = Application<{
+  'roles': Role,
+  'teams': Team,
+  'users': User,
   // !code: moduleExports // !end
-}
-
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/examples/ts/07-fakes/feathers-app/src/app.ts
+++ b/examples/ts/07-fakes/feathers-app/src/app.ts
@@ -9,10 +9,9 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
-import { Services } from './app.interface';
 import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
@@ -25,7 +24,7 @@ import mongoose from './mongoose';
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/examples/ts/09-graphql/feathers-app/src/app.ts
+++ b/examples/ts/09-graphql/feathers-app/src/app.ts
@@ -9,10 +9,9 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
-import { Services } from './app.interface';
 import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
@@ -25,7 +24,7 @@ import mongoose from './mongoose';
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/examples/ts/09-graphql/feathers-app/src/services/graphql/batchloader.resolvers.ts
+++ b/examples/ts/09-graphql/feathers-app/src/services/graphql/batchloader.resolvers.ts
@@ -20,7 +20,7 @@ export interface BatchloaderResolverOptions {
 // !code: imports // !end
 // !code: init // !end
 
-let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions) {
+let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions ) {
   // tslint:disable-next-line
   let { convertArgsToParams, convertArgsToFeathers, extractAllItems, extractFirstItem,
     feathersBatchLoader: { feathersBatchLoader } } = options;
@@ -74,83 +74,83 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Role.users: [User!]
+    // !<DEFAULT> code: bl-Role-users
+    case 'Role.users':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'roleId',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { roleId: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return users.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Team.members: [User!]
+    // !<DEFAULT> code: bl-Team-members
+    case 'Team.members':
+      return feathersBatchLoader(dataLoaderName, '[!]', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return users.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Role.users: [User!]
-      // !<DEFAULT> code: bl-Role-users
-      case 'Role.users':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'roleId',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { roleId: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return users.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
+    // User.role(query: JSON, params: JSON, key: JSON): Role
+    // !<DEFAULT> code: bl-User-role
+    case 'User.role':
+      return feathersBatchLoader(dataLoaderName, '', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return roles.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      // Team.members: [User!]
-      // !<DEFAULT> code: bl-Team-members
-      case 'Team.members':
-        return feathersBatchLoader(dataLoaderName, '[!]', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return users.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
+    // User.teams(query: JSON, params: JSON, key: JSON): [Team!]
+    // !<DEFAULT> code: bl-User-teams
+    case 'User.teams':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'memberIds',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { memberIds: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return teams.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      // User.role(query: JSON, params: JSON, key: JSON): Role
-      // !<DEFAULT> code: bl-User-role
-      case 'User.role':
-        return feathersBatchLoader(dataLoaderName, '', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return roles.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // User.teams(query: JSON, params: JSON, key: JSON): [Team!]
-      // !<DEFAULT> code: bl-User-teams
-      case 'User.teams':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'memberIds',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { memberIds: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return teams.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -177,7 +177,7 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
 
       // fullName: String!
       // !<DEFAULT> code: resolver-User-fullName-non
-      fullName: (parent: any, args: any, content: any, ast: any) => { throw Error('GraphQL fieldName User.fullName is not calculated.'); },
+      fullName: (parent, args, content, ast) => { throw Error('GraphQL fieldName User.fullName is not calculated.'); },
       // !end
 
       // role(query: JSON, params: JSON, key: JSON): Role
@@ -196,42 +196,42 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
 
       // !<DEFAULT> code: query-Role
       // getRole(query: JSON, params: JSON, key: JSON): Role
-      getRole(parent: any, args: any, content: any, ast: any) {
+      getRole(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return roles.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findRole(query: JSON, params: JSON): [Role!]
-      findRole(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { name: 1 } } });
+      findRole(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return roles.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Team
       // getTeam(query: JSON, params: JSON, key: JSON): Team
-      getTeam(parent: any, args: any, content: any, ast: any) {
+      getTeam(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return teams.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findTeam(query: JSON, params: JSON): [Team!]
-      findTeam(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { name: 1 } } });
+      findTeam(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return teams.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-User
       // getUser(query: JSON, params: JSON, key: JSON): User
-      getUser(parent: any, args: any, content: any, ast: any) {
+      getUser(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return users.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findUser(query: JSON, params: JSON): [User!]
-      findUser(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { lastName: 1, firstName: 1 } } });
+      findUser(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   lastName: 1,   firstName: 1 } } });
         return users.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/examples/ts/09-graphql/feathers-app/src/services/graphql/service.resolvers.ts
+++ b/examples/ts/09-graphql/feathers-app/src/services/graphql/service.resolvers.ts
@@ -14,7 +14,7 @@ export interface ServiceResolverOptions {
 }
 
 let moduleExports = function serviceResolvers(app: App, options: ServiceResolverOptions) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -32,7 +32,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // users: [User!]
       users:
         // !<DEFAULT> code: resolver-Role-users
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { roleId: parent._id, $sort: undefined }, paginate: false
           });
@@ -46,7 +46,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // members: [User!]
       members:
         // !<DEFAULT> code: resolver-Team-members
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: { $in: parent.memberIds }, $sort: 
               {
@@ -64,13 +64,13 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // fullName: String!
       fullName:
         // !<DEFAULT> code: resolver-User-fullName-non
-        (parent: any, args: any, content: any, ast: any) => { throw Error('GraphQL fieldName User.fullName is not calculated.'); },
+        (parent, args, content, ast) => { throw Error('GraphQL fieldName User.fullName is not calculated.'); },
         // !end
 
       // role(query: JSON, params: JSON, key: JSON): Role
       role:
         // !<DEFAULT> code: resolver-User-role
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.roleId }, paginate: false
           });
@@ -81,7 +81,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // teams(query: JSON, params: JSON, key: JSON): [Team!]
       teams:
         // !<DEFAULT> code: resolver-User-teams
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { $sort: 
               {
@@ -106,13 +106,13 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-Role
       // getRole(query: JSON, params: JSON, key: JSON): Role
-      getRole(parent: any, args: any, content: any, ast: any) {
+      getRole(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return roles.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findRole(query: JSON, params: JSON): [Role!]
-      findRole(parent: any, args: any, content: any, ast: any) {
+      findRole(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return roles.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
@@ -120,13 +120,13 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-Team
       // getTeam(query: JSON, params: JSON, key: JSON): Team
-      getTeam(parent: any, args: any, content: any, ast: any) {
+      getTeam(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return teams.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findTeam(query: JSON, params: JSON): [Team!]
-      findTeam(parent: any, args: any, content: any, ast: any) {
+      findTeam(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return teams.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
@@ -134,13 +134,13 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-User
       // getUser(query: JSON, params: JSON, key: JSON): User
-      getUser(parent: any, args: any, content: any, ast: any) {
+      getUser(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return users.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findUser(query: JSON, params: JSON): [User!]
-      findUser(parent: any, args: any, content: any, ast: any) {
+      findUser(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   lastName: 1,   firstName: 1 } } });
         return users.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },

--- a/examples/ts/10-hook/feathers-app/src/app.interface.ts
+++ b/examples/ts/10-hook/feathers-app/src/app.interface.ts
@@ -19,14 +19,11 @@ import { User } from './services/users/users.interface';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
-  'roles': Role;
-  'teams': Team;
-  'users': User;
+export type App = Application<{
+  'roles': Role,
+  'teams': Team,
+  'users': User,
   // !code: moduleExports // !end
-}
-
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/examples/ts/10-hook/feathers-app/src/app.ts
+++ b/examples/ts/10-hook/feathers-app/src/app.ts
@@ -9,10 +9,9 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
-import { Services } from './app.interface';
 import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
@@ -25,7 +24,7 @@ import mongoose from './mongoose';
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/examples/ts/10-hook/feathers-app/src/services/graphql/batchloader.resolvers.ts
+++ b/examples/ts/10-hook/feathers-app/src/services/graphql/batchloader.resolvers.ts
@@ -20,7 +20,7 @@ export interface BatchloaderResolverOptions {
 // !code: imports // !end
 // !code: init // !end
 
-let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions) {
+let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions ) {
   // tslint:disable-next-line
   let { convertArgsToParams, convertArgsToFeathers, extractAllItems, extractFirstItem,
     feathersBatchLoader: { feathersBatchLoader } } = options;
@@ -74,83 +74,83 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Role.users: [User!]
+    // !<DEFAULT> code: bl-Role-users
+    case 'Role.users':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'roleId',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { roleId: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return users.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Team.members: [User!]
+    // !<DEFAULT> code: bl-Team-members
+    case 'Team.members':
+      return feathersBatchLoader(dataLoaderName, '[!]', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return users.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Role.users: [User!]
-      // !<DEFAULT> code: bl-Role-users
-      case 'Role.users':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'roleId',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { roleId: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return users.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
+    // User.role(query: JSON, params: JSON, key: JSON): Role
+    // !<DEFAULT> code: bl-User-role
+    case 'User.role':
+      return feathersBatchLoader(dataLoaderName, '', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return roles.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      // Team.members: [User!]
-      // !<DEFAULT> code: bl-Team-members
-      case 'Team.members':
-        return feathersBatchLoader(dataLoaderName, '[!]', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return users.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
+    // User.teams(query: JSON, params: JSON, key: JSON): [Team!]
+    // !<DEFAULT> code: bl-User-teams
+    case 'User.teams':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'memberIds',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { memberIds: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return teams.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      // User.role(query: JSON, params: JSON, key: JSON): Role
-      // !<DEFAULT> code: bl-User-role
-      case 'User.role':
-        return feathersBatchLoader(dataLoaderName, '', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return roles.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // User.teams(query: JSON, params: JSON, key: JSON): [Team!]
-      // !<DEFAULT> code: bl-User-teams
-      case 'User.teams':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'memberIds',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { memberIds: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return teams.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -177,7 +177,7 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
 
       // fullName: String!
       // !<DEFAULT> code: resolver-User-fullName-non
-      fullName: (parent: any, args: any, content: any, ast: any) => { throw Error('GraphQL fieldName User.fullName is not calculated.'); },
+      fullName: (parent, args, content, ast) => { throw Error('GraphQL fieldName User.fullName is not calculated.'); },
       // !end
 
       // role(query: JSON, params: JSON, key: JSON): Role
@@ -196,42 +196,42 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
 
       // !<DEFAULT> code: query-Role
       // getRole(query: JSON, params: JSON, key: JSON): Role
-      getRole(parent: any, args: any, content: any, ast: any) {
+      getRole(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return roles.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findRole(query: JSON, params: JSON): [Role!]
-      findRole(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { name: 1 } } });
+      findRole(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return roles.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Team
       // getTeam(query: JSON, params: JSON, key: JSON): Team
-      getTeam(parent: any, args: any, content: any, ast: any) {
+      getTeam(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return teams.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findTeam(query: JSON, params: JSON): [Team!]
-      findTeam(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { name: 1 } } });
+      findTeam(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return teams.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-User
       // getUser(query: JSON, params: JSON, key: JSON): User
-      getUser(parent: any, args: any, content: any, ast: any) {
+      getUser(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return users.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findUser(query: JSON, params: JSON): [User!]
-      findUser(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { lastName: 1, firstName: 1 } } });
+      findUser(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   lastName: 1,   firstName: 1 } } });
         return users.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/examples/ts/10-hook/feathers-app/src/services/graphql/service.resolvers.ts
+++ b/examples/ts/10-hook/feathers-app/src/services/graphql/service.resolvers.ts
@@ -14,7 +14,7 @@ export interface ServiceResolverOptions {
 }
 
 let moduleExports = function serviceResolvers(app: App, options: ServiceResolverOptions) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -32,7 +32,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // users: [User!]
       users:
         // !<DEFAULT> code: resolver-Role-users
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { roleId: parent._id, $sort: undefined }, paginate: false
           });
@@ -46,7 +46,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // members: [User!]
       members:
         // !<DEFAULT> code: resolver-Team-members
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: { $in: parent.memberIds }, $sort: 
               {
@@ -64,13 +64,13 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // fullName: String!
       fullName:
         // !<DEFAULT> code: resolver-User-fullName-non
-        (parent: any, args: any, content: any, ast: any) => { throw Error('GraphQL fieldName User.fullName is not calculated.'); },
+        (parent, args, content, ast) => { throw Error('GraphQL fieldName User.fullName is not calculated.'); },
         // !end
 
       // role(query: JSON, params: JSON, key: JSON): Role
       role:
         // !<DEFAULT> code: resolver-User-role
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.roleId }, paginate: false
           });
@@ -81,7 +81,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // teams(query: JSON, params: JSON, key: JSON): [Team!]
       teams:
         // !<DEFAULT> code: resolver-User-teams
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { $sort: 
               {
@@ -106,13 +106,13 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-Role
       // getRole(query: JSON, params: JSON, key: JSON): Role
-      getRole(parent: any, args: any, content: any, ast: any) {
+      getRole(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return roles.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findRole(query: JSON, params: JSON): [Role!]
-      findRole(parent: any, args: any, content: any, ast: any) {
+      findRole(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return roles.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
@@ -120,13 +120,13 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-Team
       // getTeam(query: JSON, params: JSON, key: JSON): Team
-      getTeam(parent: any, args: any, content: any, ast: any) {
+      getTeam(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return teams.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findTeam(query: JSON, params: JSON): [Team!]
-      findTeam(parent: any, args: any, content: any, ast: any) {
+      findTeam(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return teams.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
@@ -134,13 +134,13 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-User
       // getUser(query: JSON, params: JSON, key: JSON): User
-      getUser(parent: any, args: any, content: any, ast: any) {
+      getUser(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return users.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findUser(query: JSON, params: JSON): [User!]
-      findUser(parent: any, args: any, content: any, ast: any) {
+      findUser(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   lastName: 1,   firstName: 1 } } });
         return users.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },

--- a/examples/ts/11-test/feathers-app/src/app.interface.ts
+++ b/examples/ts/11-test/feathers-app/src/app.interface.ts
@@ -19,14 +19,11 @@ import { User } from './services/users/users.interface';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
-  'roles': Role;
-  'teams': Team;
-  'users': User;
+export type App = Application<{
+  'roles': Role,
+  'teams': Team,
+  'users': User,
   // !code: moduleExports // !end
-}
-
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/examples/ts/11-test/feathers-app/src/app.ts
+++ b/examples/ts/11-test/feathers-app/src/app.ts
@@ -9,10 +9,9 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
-import { Services } from './app.interface';
 import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
@@ -25,7 +24,7 @@ import mongoose from './mongoose';
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/examples/ts/11-test/feathers-app/src/services/graphql/batchloader.resolvers.ts
+++ b/examples/ts/11-test/feathers-app/src/services/graphql/batchloader.resolvers.ts
@@ -20,7 +20,7 @@ export interface BatchloaderResolverOptions {
 // !code: imports // !end
 // !code: init // !end
 
-let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions) {
+let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions ) {
   // tslint:disable-next-line
   let { convertArgsToParams, convertArgsToFeathers, extractAllItems, extractFirstItem,
     feathersBatchLoader: { feathersBatchLoader } } = options;
@@ -74,83 +74,83 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Role.users: [User!]
+    // !<DEFAULT> code: bl-Role-users
+    case 'Role.users':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'roleId',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { roleId: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return users.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Team.members: [User!]
+    // !<DEFAULT> code: bl-Team-members
+    case 'Team.members':
+      return feathersBatchLoader(dataLoaderName, '[!]', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return users.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Role.users: [User!]
-      // !<DEFAULT> code: bl-Role-users
-      case 'Role.users':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'roleId',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { roleId: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return users.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
+    // User.role(query: JSON, params: JSON, key: JSON): Role
+    // !<DEFAULT> code: bl-User-role
+    case 'User.role':
+      return feathersBatchLoader(dataLoaderName, '', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return roles.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      // Team.members: [User!]
-      // !<DEFAULT> code: bl-Team-members
-      case 'Team.members':
-        return feathersBatchLoader(dataLoaderName, '[!]', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return users.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
+    // User.teams(query: JSON, params: JSON, key: JSON): [Team!]
+    // !<DEFAULT> code: bl-User-teams
+    case 'User.teams':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'memberIds',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { memberIds: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return teams.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      // User.role(query: JSON, params: JSON, key: JSON): Role
-      // !<DEFAULT> code: bl-User-role
-      case 'User.role':
-        return feathersBatchLoader(dataLoaderName, '', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return roles.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // User.teams(query: JSON, params: JSON, key: JSON): [Team!]
-      // !<DEFAULT> code: bl-User-teams
-      case 'User.teams':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'memberIds',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { memberIds: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return teams.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -177,7 +177,7 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
 
       // fullName: String!
       // !<DEFAULT> code: resolver-User-fullName-non
-      fullName: (parent: any, args: any, content: any, ast: any) => { throw Error('GraphQL fieldName User.fullName is not calculated.'); },
+      fullName: (parent, args, content, ast) => { throw Error('GraphQL fieldName User.fullName is not calculated.'); },
       // !end
 
       // role(query: JSON, params: JSON, key: JSON): Role
@@ -196,42 +196,42 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
 
       // !<DEFAULT> code: query-Role
       // getRole(query: JSON, params: JSON, key: JSON): Role
-      getRole(parent: any, args: any, content: any, ast: any) {
+      getRole(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return roles.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findRole(query: JSON, params: JSON): [Role!]
-      findRole(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { name: 1 } } });
+      findRole(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return roles.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Team
       // getTeam(query: JSON, params: JSON, key: JSON): Team
-      getTeam(parent: any, args: any, content: any, ast: any) {
+      getTeam(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return teams.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findTeam(query: JSON, params: JSON): [Team!]
-      findTeam(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { name: 1 } } });
+      findTeam(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return teams.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-User
       // getUser(query: JSON, params: JSON, key: JSON): User
-      getUser(parent: any, args: any, content: any, ast: any) {
+      getUser(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return users.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findUser(query: JSON, params: JSON): [User!]
-      findUser(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { lastName: 1, firstName: 1 } } });
+      findUser(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   lastName: 1,   firstName: 1 } } });
         return users.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/examples/ts/11-test/feathers-app/src/services/graphql/service.resolvers.ts
+++ b/examples/ts/11-test/feathers-app/src/services/graphql/service.resolvers.ts
@@ -14,7 +14,7 @@ export interface ServiceResolverOptions {
 }
 
 let moduleExports = function serviceResolvers(app: App, options: ServiceResolverOptions) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -32,7 +32,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // users: [User!]
       users:
         // !<DEFAULT> code: resolver-Role-users
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { roleId: parent._id, $sort: undefined }, paginate: false
           });
@@ -46,7 +46,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // members: [User!]
       members:
         // !<DEFAULT> code: resolver-Team-members
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: { $in: parent.memberIds }, $sort: 
               {
@@ -64,13 +64,13 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // fullName: String!
       fullName:
         // !<DEFAULT> code: resolver-User-fullName-non
-        (parent: any, args: any, content: any, ast: any) => { throw Error('GraphQL fieldName User.fullName is not calculated.'); },
+        (parent, args, content, ast) => { throw Error('GraphQL fieldName User.fullName is not calculated.'); },
         // !end
 
       // role(query: JSON, params: JSON, key: JSON): Role
       role:
         // !<DEFAULT> code: resolver-User-role
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.roleId }, paginate: false
           });
@@ -81,7 +81,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // teams(query: JSON, params: JSON, key: JSON): [Team!]
       teams:
         // !<DEFAULT> code: resolver-User-teams
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { $sort: 
               {
@@ -106,13 +106,13 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-Role
       // getRole(query: JSON, params: JSON, key: JSON): Role
-      getRole(parent: any, args: any, content: any, ast: any) {
+      getRole(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return roles.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findRole(query: JSON, params: JSON): [Role!]
-      findRole(parent: any, args: any, content: any, ast: any) {
+      findRole(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return roles.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
@@ -120,13 +120,13 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-Team
       // getTeam(query: JSON, params: JSON, key: JSON): Team
-      getTeam(parent: any, args: any, content: any, ast: any) {
+      getTeam(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return teams.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findTeam(query: JSON, params: JSON): [Team!]
-      findTeam(parent: any, args: any, content: any, ast: any) {
+      findTeam(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   name: 1 } } });
         return teams.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
@@ -134,13 +134,13 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-User
       // getUser(query: JSON, params: JSON, key: JSON): User
-      getUser(parent: any, args: any, content: any, ast: any) {
+      getUser(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return users.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findUser(query: JSON, params: JSON): [User!]
-      findUser(parent: any, args: any, content: any, ast: any) {
+      findUser(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   lastName: 1,   firstName: 1 } } });
         return users.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },

--- a/generators/writing/templates/src/app.ejs
+++ b/generators/writing/templates/src/app.ejs
@@ -16,10 +16,9 @@ process.env['NODE_CONFIG_DIR'] = './<%- appConfigPath %>'<%- sc %>
 <% } -%>
 <%# --- if-1 ends above. -%>
 <%- tplImports('configuration', '@feathersjs/configuration') %>
-<%- tplJsOrTs(tplImports('express', '@feathersjs/express'), tplImports('express, { Application }', '@feathersjs/express')) %>
+<%- tplImports('express', '@feathersjs/express') %>
 <%- hasProvider('socketio') ? tplImports('socketio', '@feathersjs/socketio') : '' %>
 <%- hasProvider('primus') ? tplImports('primus', '@feathersjs/primus') : '' %>
-<%- tplTsOnly(`import { Services } from './app.interface'${sc}`) %>
 <%- tplImports('middleware', './middleware') %>
 <%- tplImports('services', './services') %>
 <%- tplImports('appHooks', './app.hooks') %>
@@ -45,7 +44,7 @@ const generatorSpecs = require('../feathers-gen-specs.json')<%- sc %>
 <%- insertFragment('imports') %>
 <%- insertFragment('init') %>
 
-const app = <%- tplJsOrTs('express(feathers())', 'express<Services>(feathers() as Application<Services>)') %><%- sc %>
+const app = express(feathers())<%- sc %>
 <%- insertFragment('use_start') %>
 
 // Load app configuration

--- a/generators/writing/templates/src/app.interface.ejs
+++ b/generators/writing/templates/src/app.interface.ejs
@@ -26,17 +26,14 @@ import { <%- __importName %> } from './services/<%- __subFolder %><%- __kName %>
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
+export type App = Application<{
 <%# -%>
 <%# --- forEach-2 starts below. Loop thru the services. -%>
 <% Object.keys(specs.services || {}).sort().forEach(__name => { -%>
-  '<%- specs.services[__name].fileName %>': <%- upperFirst(specs.services[__name].nameSingular) %>;
+  '<%- specs.services[__name].fileName %>': <%- upperFirst(specs.services[__name].nameSingular) %>,
 <% }); -%>
 <%# --- forEach-2 ends above. -%>
   <%- insertFragment('moduleExports') %>
-}
-
-export type App = Application<Services>;
+}>;
 <%- insertFragment('funcs') %>
 <%- insertFragment('end') %>

--- a/generators/writing/templates/src/seed-data.ejs
+++ b/generators/writing/templates/src/seed-data.ejs
@@ -5,18 +5,13 @@
 <%- tplTsOnly(`import { App } from './app.interface'${sc}`) %>
 <%- insertFragment('imports') %>
 
-
-<%- tplTsOnly(`interface TestConfig {
-  environmentsAllowingSeedData?: string[];
-}`) %>
-
 // Determine if command line argument exists for seeding data
 let ifSeedServices = ['--seed', '-s'].some(str => process.argv.slice(2).includes(str))<%- sc %>
 
 // Determine if environment allows test to mutate existing DB data.
-function areDbChangesAllowed(testConfig<%- tplTsOnly(`: TestConfig`) -%>) {
-  let { environmentsAllowingSeedData = [] } = testConfig || {}<%- sc %>
-  return environmentsAllowingSeedData.includes(process.env.NODE_ENV<%- tplTsOnly(` as string`) -%>)<%- sc %>
+function areDbChangesAllowed(testConfig) {
+  let { environmentsAllowingSeedData = [] } = testConfig<%- sc %>
+  return environmentsAllowingSeedData.includes(process.env.NODE_ENV)<%- sc %>
 }
 
 // Get generated fake data
@@ -27,7 +22,7 @@ let services = (readJsonFileSync(join(__dirname, '../feathers-gen-specs.json')) 
 <%- insertFragment('init') %>
 
 <%- tplExport('async function (app) {', 'async function (app: App) {') %>
-  const ifDbChangesAllowed = areDbChangesAllowed(app.get('tests'))<%- sc %>
+  const ifDbChangesAllowed = areDbChangesAllowed(app.get("tests"))<%- sc %>
   <%- insertFragment('func_init') %>
   if (!ifSeedServices) return<%- sc %>
   if (!ifDbChangesAllowed) return<%- sc %>

--- a/generators/writing/templates/src/services/graphql/batchloader.resolvers.ejs
+++ b/generators/writing/templates/src/services/graphql/batchloader.resolvers.ejs
@@ -27,7 +27,7 @@
 <%- insertFragment('imports') %>
 <%- insertFragment('init') %>
 
-let moduleExports = function batchLoaderResolvers<%- tplJsOrTs('(app, options)', '(app: App, options: BatchloaderResolverOptions)') %> {
+let moduleExports = function batchLoaderResolvers<%- tplJsOrTs('(app, options)', '(app: App, options: BatchloaderResolverOptions )') %> {
   // <%- lintDisableNextLine %>
   let { convertArgsToParams, convertArgsToFeathers, extractAllItems, extractFirstItem,
     feathersBatchLoader: { feathersBatchLoader } } = options<%- sc %>
@@ -93,18 +93,18 @@ let moduleExports = function batchLoaderResolvers<%- tplJsOrTs('(app, options)',
     let feathersParams<%- sc %>
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      <%- insertFragment('bl-persisted', [
-      '      // case \'_persisted.user.one.id\': // service user, returns one object, key is field id',
-      ]) %>
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    <%- insertFragment('bl-persisted', [
+      '    // case \'_persisted.user.one.id\': // service user, returns one object, key is field id',
+    ]) %>
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      <%- insertFragment('bl-shared', [
-      '      // *.*: User',
-      '      // case \'_shared.user.one.id\': // service user, returns one object, key is field id',
-      ]) %>
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    <%- insertFragment('bl-shared', [
+        '    // *.*: User',
+        '    // case \'_shared.user.one.id\': // service user, returns one object, key is field id',
+    ]) %>
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
 <%# -%>
 <%# --- forEach-a starts below. Loop thru the schemas of GraphQL enabled services. -%>
 <% Object.keys(mapping.graphqlService).forEach(graphqlName => {
@@ -124,24 +124,24 @@ let moduleExports = function batchLoaderResolvers<%- tplJsOrTs('(app, options)',
     __code = __addField.isNullable ? '' : '!';
   }
   __temp = [
-    `      case '${graphqlName}.${fieldName}':`,
-    `        return feathersBatchLoader(dataLoaderName, '${__code}', '${__addField.relation.otherTable}',`,
+    `    case '${graphqlName}.${fieldName}':`,
+    `      return feathersBatchLoader(dataLoaderName, '${__code}', '${__addField.relation.otherTable}',`,
     isJs ?
-    '          keys => {' :
-    '          (keys: string[]) => {',
-    '            feathersParams = convertArgs(args, content, null, {',
-    `              query: { ${__addField.relation.otherTable}: { $in: keys }, $sort: undefined },`,
-    '              _populate: \'skip\', paginate: false',
-    `            })${sc}`,
-    `            return ${__addField.serviceName}.find(feathersParams)${sc}`,
-    '          },',
-    '          maxBatchSize // Max #keys in a BatchLoader func call.',
-    `        )${sc}`,
+      '        keys => {' :
+      '        (keys: string[]) => {',
+    '          feathersParams = convertArgs(args, content, null, {',
+    `            query: { ${__addField.relation.otherTable}: { $in: keys }, $sort: undefined },`,
+    '            _populate: \'skip\', paginate: false',
+    `          })${sc}`,
+    `          return ${__addField.serviceName}.find(feathersParams)${sc}`,
+    '        },',
+    '        maxBatchSize // Max #keys in a BatchLoader func call.',
+    `      )${sc}`,
   ];
 -%>
 
-      // <%- `${graphqlName}.${fieldName}${__addField.args}: ${__addField.type}` %>
-      <%- insertFragment(`bl-${graphqlName}-${fieldName}`, __temp, undefined, { indentEnd: 0 }) %>
+    // <%- `${graphqlName}.${fieldName}${__addField.args}: ${__addField.type}` %>
+    <%- insertFragment(`bl-${graphqlName}-${fieldName}`, __temp, undefined, { indentEnd: 2 }) %>
 <% } -%>
 <%# --- if-c ends above. -%>
 <% }); -%>
@@ -149,11 +149,11 @@ let moduleExports = function batchLoaderResolvers<%- tplJsOrTs('(app, options)',
 <% }); -%>
 <%# --- forEach-a ends above. -%>
 
-      /* Throw on unknown BatchLoader name. */
-      default:
-        <%- insertFragment('bl-default', [
-      '        throw new Error(`GraphQL query requires BatchLoader named \'${dataLoaderName}\' but no definition exists for it.`)' + `${sc}`,
-        ], undefined, { indentEnd: -2 }) %>
+    /* Throw on unknown BatchLoader name. */
+    default:
+      <%- insertFragment('bl-default', [
+        '      throw new Error(`GraphQL query requires BatchLoader named \'${dataLoaderName}\' but no definition exists for it.`)' + `${sc}`,
+      ]) %>
     }
   }
 <%# -%>
@@ -185,9 +185,7 @@ let moduleExports = function batchLoaderResolvers<%- tplJsOrTs('(app, options)',
       <%- insertFragment(`resolver-${graphqlName}-${fieldName}`, __temp) %>
 <% } else { -%>
       <%- insertFragment(`resolver-${graphqlName}-${fieldName}-non`, [
-        isJs ?
-          `      ${fieldName}: (parent, args, content, ast) => { throw Error('GraphQL fieldName ${graphqlName}.${fieldName} is not calculated.')${sc} },`:
-          `      ${fieldName}: (parent: any, args: ArgMap, content: ResolverContext, ast: GraphQLResolveInfo) => { throw Error('GraphQL fieldName ${graphqlName}.${fieldName} is not calculated.')${sc} },`
+        `      ${fieldName}: (parent, args, content, ast) => { throw Error('GraphQL fieldName ${graphqlName}.${fieldName} is not calculated.')${sc} },`,
       ]) %>
 <% } -%>
 <%# --- if/else-1 ends above. -%>
@@ -208,18 +206,13 @@ let moduleExports = function batchLoaderResolvers<%- tplJsOrTs('(app, options)',
   __graphql = feathersSpecs[__serviceName]._extensions.graphql;
   __temp = [
     `      // get${graphqlName}(query: JSON, params: JSON, key: JSON): ${graphqlName}`,
-    isJs ?
-    `      get${graphqlName}(parent, args, content, ast) {` :
-    `      get${graphqlName}(parent: any, args: ArgMap, content: ResolverContext, ast: GraphQLResolveInfo) {`,
+    `      get${graphqlName}(parent, args, content, ast) {`,
     `        const feathersParams = convertArgs(args, content, ast)${sc}`,
     `        return ${__serviceName}.get(args.key, feathersParams).then(extractFirstItem)${sc}`,
     '      },',
     '',
     `      // find${graphqlName}(query: JSON, params: JSON): [${graphqlName}!]`,
-    
-    isJs ? 
-          `      find${graphqlName}(parent, args, content, ast) {` :
-          `      find${graphqlName}(parent: any, args: ArgMap, content: ResolverContext, ast: GraphQLResolveInfo) {`,
+    `      find${graphqlName}(parent, args, content, ast) {`,
     `        const feathersParams = convertArgs(args, content, ast${__graphql.serviceSortParams})${sc}`,
     `        return ${__serviceName}.find(feathersParams).then(paginate(content)).then(extractAllItems)${sc}`,
     '      },',

--- a/generators/writing/templates/src/services/graphql/service.resolvers.ejs
+++ b/generators/writing/templates/src/services/graphql/service.resolvers.ejs
@@ -20,7 +20,7 @@
   '',
 ]) -%>
 let moduleExports = function serviceResolvers<%- tplJsOrTs('(app, options)', '(app: App, options: ServiceResolverOptions)') %> {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options<%- sc %>
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options<%- sc %>
   <%- insertFragment('extra_auth_props', [
     `  const convertArgs = convertArgsToFeathers([])${sc}`,
   ]) %>
@@ -56,11 +56,10 @@ let moduleExports = function serviceResolvers<%- tplJsOrTs('(app, options)', '(a
 <%# -%>
 <%# --- if/else-1 starts below. Whether field is a join or a calculated field. -%>
 <% if (__addField.serviceName) {
-  deIndent = true;
   // Field in other table is not an array
   if (!__addField.relation.otherTableIsArray) {
     __temp = [
-      `        ${tplJsOrTs('(parent, args, content, ast)', '(parent: any, args: ArgMap, content: ResolverContext, ast: GraphQLResolveInfo)')} => {`,
+      '        (parent, args, content, ast) => {',
       '          const feathersParams = convertArgs(args, content, ast, {',
       `            query: { ${__addField.relation.otherTable}: `
         + `${__addField.relation.ourTableIsArray ? '{ $in: ' : ''}parent.${__addField.relation.ourTable}${__addField.relation.ourTableIsArray ? ' }' : ''}`
@@ -74,7 +73,7 @@ let moduleExports = function serviceResolvers<%- tplJsOrTs('(app, options)', '(a
   } else {
   // Field in other table is an array
     __temp = [
-      `        ${tplJsOrTs('(parent, args, content, ast)', '(parent: any, args: ArgMap, content: ResolverContext, ast: GraphQLResolveInfo)')} => {`,
+      '        (parent, args, content, ast) => {',
       '          const feathersParams = convertArgs(args, content, ast, {',
       `            query: { ${__$sort} }, paginate: false`,
       `          })${sc}`
@@ -100,13 +99,10 @@ let moduleExports = function serviceResolvers<%- tplJsOrTs('(app, options)', '(a
     }
   }
 -%>
-        <%- insertFragment(`resolver-${graphqlName}-${fieldName}`, __temp, undefined, { indentEnd: -2 }) %>
+        <%- insertFragment(`resolver-${graphqlName}-${fieldName}`, __temp) %>
 <% } else { -%>
-        <%- insertFragment(`resolver-${graphqlName}-${fieldName}-non`, [
-          `        ${tplJsOrTs('(parent, args, content, ast)', '(parent: any, args: ArgMap, content: ResolverContext, ast: GraphQLResolveInfo)')} => {`,
-          `           throw Error('GraphQL fieldName ${graphqlName}.${fieldName} is not calculated.')${sc}`,
-          `        },`
-          ]
+        <%- insertFragment(`resolver-${graphqlName}-${fieldName}-non`,
+          `        (parent, args, content, ast) => { throw Error('GraphQL fieldName ${graphqlName}.${fieldName} is not calculated.')${sc} },`
         ) %>
 <% } -%>
 <%# --- if/else-1 ends above. -%>
@@ -126,13 +122,13 @@ let moduleExports = function serviceResolvers<%- tplJsOrTs('(app, options)', '(a
   __graphql = feathersSpecs[__serviceName]._extensions.graphql;
   __temp = [
     `      // get${graphqlName}(query: JSON, params: JSON, key: JSON): ${graphqlName}`,
-    `      get${graphqlName}${tplJsOrTs('(parent, args, content, ast)', '(parent: any, args: ArgMap, content: ResolverContext, ast: GraphQLResolveInfo)')} {`,
+    `      get${graphqlName}(parent, args, content, ast) {`,
     `        const feathersParams = convertArgs(args, content, ast)${sc}`,
     `        return ${__serviceName}.get(args.key, feathersParams).then(extractFirstItem)${sc}`,
     '      },',
     '',
     `      // find${graphqlName}(query: JSON, params: JSON): [${graphqlName}!]`,
-    `      find${graphqlName}${tplJsOrTs('(parent, args, content, ast)', '(parent: any, args: ArgMap, content: ResolverContext, ast: GraphQLResolveInfo)')} {`,
+    `      find${graphqlName}(parent, args, content, ast) {`,
     `        const feathersParams = convertArgs(args, content, ast${__graphql.serviceSortParams})${sc}`,
     `        return ${__serviceName}.find(feathersParams).then(paginate(content)).then(extractAllItems)${sc}`,
     '      },',

--- a/misc/authentication-template/app/services/graphql/batchloader.resolvers.js
+++ b/misc/authentication-template/app/services/graphql/batchloader.resolvers.js
@@ -55,175 +55,175 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      //!<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
-      //!end
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    //!<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    //!end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      //!code: bl-shared
-      // *.*: User
-      case '_shared.user.one.uuid': // service user, returns one object, key is field uuid
-        return feathersBatchLoader(dataLoaderName, '!', 'uuid',
-          keys => {
-            feathersParams = convertArgsToFeathers(args, graphqlContent, null,
-              { query: { uuid: { $in: keys } } }
-            );
-            return user.find(feathersParams);
-          },
-          50
-        );
-      //!end
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    //!code: bl-shared
+    // *.*: User
+    case '_shared.user.one.uuid': // service user, returns one object, key is field uuid
+      return feathersBatchLoader(dataLoaderName, '!', 'uuid',
+        keys => {
+          feathersParams = convertArgsToFeathers(args, graphqlContent, null,
+            { query : { uuid: { $in: keys } } }
+          );
+          return user.find(feathersParams);
+        },
+        50
+      );
+    //!end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
 
-      // Comment.author: User!
-      //!code: bl-Comment-author
+    // Comment.author: User!
+    //!code: bl-Comment-author
       // ... Using instead _shared.user.one.id
       //!end
 
-      // Comment.likes: [Like!]
-      //!<DEFAULT> code: bl-Comment-likes
-      case 'Comment.likes':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'commentUuid',
-          keys => {
-            feathersParams = convertArgsToFeathers(args, graphqlContent, null, {
-              query: { commentUuid: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return like.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      //!end
+    // Comment.likes: [Like!]
+    //!<DEFAULT> code: bl-Comment-likes
+    case 'Comment.likes':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'commentUuid',
+        keys => {
+          feathersParams = convertArgsToFeathers(args, graphqlContent, null, {
+            query: { commentUuid: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return like.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
+    //!end
 
-      // Like.author: User!
-      //!code: bl-Like-author
+    // Like.author: User!
+    //!code: bl-Like-author
       // ... Using instead _shared.user.one.id
       //!end
 
-      // Like.comment: Comment!
-      //!<DEFAULT> code: bl-Like-comment
-      case 'Like.comment':
-        return feathersBatchLoader(dataLoaderName, '!', 'uuid',
-          keys => {
-            feathersParams = convertArgsToFeathers(args, graphqlContent, null, {
-              query: { uuid: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return comment.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      //!end
+    // Like.comment: Comment!
+    //!<DEFAULT> code: bl-Like-comment
+    case 'Like.comment':
+      return feathersBatchLoader(dataLoaderName, '!', 'uuid',
+        keys => {
+          feathersParams = convertArgsToFeathers(args, graphqlContent, null, {
+            query: { uuid: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return comment.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
+    //!end
 
-      // Post.author: User!
-      //!code: bl-Post-author
+    // Post.author: User!
+    //!code: bl-Post-author
       // ... Using instead _shared.user.one.id
       //!end
 
-      // Post.comments: [Comment!]
-      //!<DEFAULT> code: bl-Post-comments
-      case 'Post.comments':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'postUuid',
-          keys => {
-            feathersParams = convertArgsToFeathers(args, graphqlContent, null, {
-              query: { postUuid: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return comment.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      //!end
+    // Post.comments: [Comment!]
+    //!<DEFAULT> code: bl-Post-comments
+    case 'Post.comments':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'postUuid',
+        keys => {
+          feathersParams = convertArgsToFeathers(args, graphqlContent, null, {
+            query: { postUuid: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return comment.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
+    //!end
 
-      // Relationship.follower: User!
-      //!code: bl-Relationship-follower
+    // Relationship.follower: User!
+    //!code: bl-Relationship-follower
       // ... Using instead _shared.user.one.id
       //!end
 
-      // Relationship.followee: User!
-      //!code: bl-Relationship-followee
+    // Relationship.followee: User!
+    //!code: bl-Relationship-followee
       // ... Using instead _shared.user.one.id
       //!end
 
-      // User.comments: [Comment!]
-      //!<DEFAULT> code: bl-User-comments
-      case 'User.comments':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'authorUuid',
-          keys => {
-            feathersParams = convertArgsToFeathers(args, graphqlContent, null, {
-              query: { authorUuid: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return comment.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      //!end
+    // User.comments: [Comment!]
+    //!<DEFAULT> code: bl-User-comments
+    case 'User.comments':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'authorUuid',
+        keys => {
+          feathersParams = convertArgsToFeathers(args, graphqlContent, null, {
+            query: { authorUuid: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return comment.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
+    //!end
 
-      // User.followed_by: [Relationship!]
-      //!<DEFAULT> code: bl-User-followed_by
-      case 'User.followed_by':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'followeeUuid',
-          keys => {
-            feathersParams = convertArgsToFeathers(args, graphqlContent, null, {
-              query: { followeeUuid: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return relationship.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      //!end
+    // User.followed_by: [Relationship!]
+    //!<DEFAULT> code: bl-User-followed_by
+    case 'User.followed_by':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'followeeUuid',
+        keys => {
+          feathersParams = convertArgsToFeathers(args, graphqlContent, null, {
+            query: { followeeUuid: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return relationship.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
+    //!end
 
-      // User.following: [Relationship!]
-      //!<DEFAULT> code: bl-User-following
-      case 'User.following':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'followerUuid',
-          keys => {
-            feathersParams = convertArgsToFeathers(args, graphqlContent, null, {
-              query: { followerUuid: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return relationship.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      //!end
+    // User.following: [Relationship!]
+    //!<DEFAULT> code: bl-User-following
+    case 'User.following':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'followerUuid',
+        keys => {
+          feathersParams = convertArgsToFeathers(args, graphqlContent, null, {
+            query: { followerUuid: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return relationship.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
+    //!end
 
-      // User.likes: [Like!]
-      //!<DEFAULT> code: bl-User-likes
-      case 'User.likes':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'authorUuid',
-          keys => {
-            feathersParams = convertArgsToFeathers(args, graphqlContent, null, {
-              query: { authorUuid: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return like.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      //!end
+    // User.likes: [Like!]
+    //!<DEFAULT> code: bl-User-likes
+    case 'User.likes':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'authorUuid',
+        keys => {
+          feathersParams = convertArgsToFeathers(args, graphqlContent, null, {
+            query: { authorUuid: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return like.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
+    //!end
 
-      // User.posts(query: JSON, params: JSON, key: JSON): [Post!]
-      //!code: bl-User-posts
-      case 'User.posts':
-        return feathersBatchLoader(dataLoaderName, '[!]', 'authorUuid',
-          keys => {
-            feathersParams = convertArgsToFeathers(args, graphqlContent, null,
-              { query: { authorUuid: { $in: keys }, $sort: { uuid: 1 } }, populate: false }
-            );
-            return post.find(feathersParams);
-          }
-        );
-      //!end
+    // User.posts(query: JSON, params: JSON, key: JSON): [Post!]
+    //!code: bl-User-posts
+    case 'User.posts':
+      return feathersBatchLoader(dataLoaderName, '[!]', 'authorUuid',
+        keys => {
+          feathersParams = convertArgsToFeathers(args, graphqlContent, null,
+            { query: { authorUuid: { $in: keys }, $sort: { uuid: 1 } }, populate: false }
+          );
+          return post.find(feathersParams);
+        }
+      );
+    //!end
 
-      /* Throw on unknown BatchLoader name. */
-      default:
-        //!<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      //!<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       //!end
     }
   }
@@ -320,7 +320,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       //!<DEFAULT> code: query-Comment
       // getComment(query: JSON, params: JSON, key: JSON): Comment
-      getComment(parent, args, content, ast) {
+      getComment (parent, args, content, ast) {
         graphqlContent = content;
         const feathersParams = convertArgsToFeathers(args, content, ast);
         return comment.get(args.key, feathersParams).then(extractFirstItem);
@@ -329,14 +329,14 @@ let moduleExports = function batchLoaderResolvers(app, options) {
       // findComment(query: JSON, params: JSON): [Comment!]
       findComment(parent, args, content, ast) {
         graphqlContent = content;
-        const feathersParams = convertArgsToFeathers(args, content, ast, { query: { $sort: { uuid: 1 } } });
+        const feathersParams = convertArgsToFeathers(args, content, ast, { query: { $sort: {   uuid: 1 } } });
         return comment.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       //!end
 
       //!<DEFAULT> code: query-Like
       // getLike(query: JSON, params: JSON, key: JSON): Like
-      getLike(parent, args, content, ast) {
+      getLike (parent, args, content, ast) {
         graphqlContent = content;
         const feathersParams = convertArgsToFeathers(args, content, ast);
         return like.get(args.key, feathersParams).then(extractFirstItem);
@@ -345,14 +345,14 @@ let moduleExports = function batchLoaderResolvers(app, options) {
       // findLike(query: JSON, params: JSON): [Like!]
       findLike(parent, args, content, ast) {
         graphqlContent = content;
-        const feathersParams = convertArgsToFeathers(args, content, ast, { query: { $sort: { uuid: 1 } } });
+        const feathersParams = convertArgsToFeathers(args, content, ast, { query: { $sort: {   uuid: 1 } } });
         return like.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       //!end
 
       //!<DEFAULT> code: query-Post
       // getPost(query: JSON, params: JSON, key: JSON): Post
-      getPost(parent, args, content, ast) {
+      getPost (parent, args, content, ast) {
         graphqlContent = content;
         const feathersParams = convertArgsToFeathers(args, content, ast);
         return post.get(args.key, feathersParams).then(extractFirstItem);
@@ -360,14 +360,14 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findPost(query: JSON, params: JSON): [Post!]
       findPost(parent, args, content, ast) {
-        const feathersParams = convertArgsToFeathers(args, content, ast, { query: { $sort: { uuid: 1 } } });
+        const feathersParams = convertArgsToFeathers(args, content, ast, { query: { $sort: {   uuid: 1 } } });
         return post.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       //!end
 
       //!<DEFAULT> code: query-Relationship
       // getRelationship(query: JSON, params: JSON, key: JSON): Relationship
-      getRelationship(parent, args, content, ast) {
+      getRelationship (parent, args, content, ast) {
         graphqlContent = content;
         const feathersParams = convertArgsToFeathers(args, content, ast);
         return relationship.get(args.key, feathersParams).then(extractFirstItem);
@@ -376,14 +376,14 @@ let moduleExports = function batchLoaderResolvers(app, options) {
       // findRelationship(query: JSON, params: JSON): [Relationship!]
       findRelationship(parent, args, content, ast) {
         graphqlContent = content;
-        const feathersParams = convertArgsToFeathers(args, content, ast, { query: { $sort: { uuid: 1 } } });
+        const feathersParams = convertArgsToFeathers(args, content, ast, { query: { $sort: {   uuid: 1 } } });
         return relationship.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       //!end
 
       //!<DEFAULT> code: query-User
       // getUser(query: JSON, params: JSON, key: JSON): User
-      getUser(parent, args, content, ast) {
+      getUser (parent, args, content, ast) {
         graphqlContent = content;
         const feathersParams = convertArgsToFeathers(args, content, ast);
         return user.get(args.key, feathersParams).then(extractFirstItem);
@@ -392,7 +392,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
       // findUser(query: JSON, params: JSON): [User!]
       findUser(parent, args, content, ast) {
         graphqlContent = content;
-        const feathersParams = convertArgsToFeathers(args, content, ast, { query: { $sort: { uuid: 1 } } });
+        const feathersParams = convertArgsToFeathers(args, content, ast, { query: { $sort: {   uuid: 1 } } });
         return user.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       //!end

--- a/misc/authentication-template/app/services/graphql/service.resolvers.js
+++ b/misc/authentication-template/app/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 //!code: init //!end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   const convertArgs = convertArgsToFeathers(); // *************************************************
 
   //!<DEFAULT> code: services
@@ -26,7 +26,7 @@ let moduleExports = function serviceResolvers(app, options) {
           });
           return nedb2.find(feathersParams).then(extractFirstItem);
         },
-      //!end
+        //!end
     },
 
     Nedb2: {
@@ -40,7 +40,7 @@ let moduleExports = function serviceResolvers(app, options) {
           });
           return nedb1.find(feathersParams).then(extractFirstItem);
         },
-      //!end
+        //!end
     },
 
     //!code: resolver_field_more //!end
@@ -49,28 +49,28 @@ let moduleExports = function serviceResolvers(app, options) {
 
       //!<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent, args, content, ast) {
+      getNedb1 (parent, args, content, ast) {
         const feathersParams = convertArgsToFeathers(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgsToFeathers(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgsToFeathers(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       //!end
 
       //!<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent, args, content, ast) {
+      getNedb2 (parent, args, content, ast) {
         const feathersParams = convertArgsToFeathers(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgsToFeathers(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgsToFeathers(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       //!end

--- a/misc/internal-structures/feathersSpecs.js
+++ b/misc/internal-structures/feathersSpecs.js
@@ -38,10 +38,10 @@ const feathersSpecs = {
           }
         },
         sql: { uniqueKey: 'id', sqlColumn: {} },
-        serviceSortParams: ', { query: { $sort: {  _id: 1 } } }'
+        serviceSortParams: ', { query: { $sort: {   _id: 1 } } }'
       },
       primaryKey: { idName: '_id', idType: 'string' },
-      foreignKeys: ['id', '_id', 'nedb2Id'],
+      foreignKeys: [ 'id', '_id', 'nedb2Id' ],
       _ifGraphql: true
     }
   },
@@ -83,10 +83,10 @@ const feathersSpecs = {
           }
         },
         sql: { uniqueKey: 'id', sqlColumn: {} },
-        serviceSortParams: ', { query: { $sort: {  _id: 1 } } }'
+        serviceSortParams: ', { query: { $sort: {   _id: 1 } } }'
       },
       primaryKey: { idName: '_id', idType: 'string' },
-      foreignKeys: ['id', '_id', 'nedb1Id'],
+      foreignKeys: [ 'id', '_id', 'nedb1Id' ],
       _ifGraphql: true
     }
   },

--- a/test-expands/a-gens/js/cumulative.test-expected/src1/app.js
+++ b/test-expands/a-gens/js/cumulative.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/a-gens/js/cumulative.test-expected/src1/services/graphql/batchloader.resolvers.js
+++ b/test-expands/a-gens/js/cumulative.test-expected/src1/services/graphql/batchloader.resolvers.js
@@ -54,53 +54,53 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -135,7 +135,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -149,7 +149,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/a-gens/js/cumulative.test-expected/src1/services/graphql/service.resolvers.js
+++ b/test-expands/a-gens/js/cumulative.test-expected/src1/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -58,7 +58,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -72,7 +72,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/a-gens/js/test-authentication.test-expected/src1/app.js
+++ b/test-expands/a-gens/js/test-authentication.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/a-gens/js/test-authentication.test-expected/src1/services/graphql/batchloader.resolvers.js
+++ b/test-expands/a-gens/js/test-authentication.test-expected/src1/services/graphql/batchloader.resolvers.js
@@ -54,53 +54,53 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -135,7 +135,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -149,7 +149,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/a-gens/js/test-authentication.test-expected/src1/services/graphql/service.resolvers.js
+++ b/test-expands/a-gens/js/test-authentication.test-expected/src1/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -58,7 +58,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -72,7 +72,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/a-gens/js/test-hook-integ.test-expected/src1/app.js
+++ b/test-expands/a-gens/js/test-hook-integ.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/a-gens/js/test-hook-integ.test-expected/src1/services/graphql/batchloader.resolvers.js
+++ b/test-expands/a-gens/js/test-hook-integ.test-expected/src1/services/graphql/batchloader.resolvers.js
@@ -54,53 +54,53 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -135,7 +135,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -149,7 +149,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/a-gens/js/test-hook-integ.test-expected/src1/services/graphql/service.resolvers.js
+++ b/test-expands/a-gens/js/test-hook-integ.test-expected/src1/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -58,7 +58,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -72,7 +72,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/a-gens/js/test-hook-unit.test-expected/src1/app.js
+++ b/test-expands/a-gens/js/test-hook-unit.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/a-gens/js/test-hook-unit.test-expected/src1/services/graphql/batchloader.resolvers.js
+++ b/test-expands/a-gens/js/test-hook-unit.test-expected/src1/services/graphql/batchloader.resolvers.js
@@ -54,53 +54,53 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -135,7 +135,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -149,7 +149,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/a-gens/js/test-hook-unit.test-expected/src1/services/graphql/service.resolvers.js
+++ b/test-expands/a-gens/js/test-hook-unit.test-expected/src1/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -58,7 +58,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -72,7 +72,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/a-gens/js/test-service.test-expected/src1/app.js
+++ b/test-expands/a-gens/js/test-service.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/a-gens/js/test-service.test-expected/src1/services/graphql/batchloader.resolvers.js
+++ b/test-expands/a-gens/js/test-service.test-expected/src1/services/graphql/batchloader.resolvers.js
@@ -54,53 +54,53 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -135,7 +135,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -149,7 +149,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/a-gens/js/test-service.test-expected/src1/services/graphql/service.resolvers.js
+++ b/test-expands/a-gens/js/test-service.test-expected/src1/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -58,7 +58,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -72,7 +72,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/a-gens/ts/test-authentication.test-expected/src1/app.interface.ts
+++ b/test-expands/a-gens/ts/test-authentication.test-expected/src1/app.interface.ts
@@ -19,14 +19,11 @@ import { Users1 } from './services/users-1/users-1.interface';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
-  'nedb-1': Nedb1;
-  'nedb-2': Nedb2;
-  'users-1': Users1;
+export type App = Application<{
+  'nedb-1': Nedb1,
+  'nedb-2': Nedb2,
+  'users-1': Users1,
   // !code: moduleExports // !end
-}
-
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/test-expands/a-gens/ts/test-authentication.test-expected/src1/app.ts
+++ b/test-expands/a-gens/ts/test-authentication.test-expected/src1/app.ts
@@ -10,10 +10,9 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
-import { Services } from './app.interface';
 import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
@@ -25,7 +24,7 @@ import authentication from './authentication';
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/test-expands/a-gens/ts/test-authentication.test-expected/src1/services/graphql/batchloader.resolvers.ts
+++ b/test-expands/a-gens/ts/test-authentication.test-expected/src1/services/graphql/batchloader.resolvers.ts
@@ -20,7 +20,7 @@ export interface BatchloaderResolverOptions {
 // !code: imports // !end
 // !code: init // !end
 
-let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions) {
+let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions ) {
   // tslint:disable-next-line
   let { convertArgsToParams, convertArgsToFeathers, extractAllItems, extractFirstItem,
     feathersBatchLoader: { feathersBatchLoader } } = options;
@@ -73,53 +73,53 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -147,28 +147,28 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/a-gens/ts/test-authentication.test-expected/src1/services/graphql/service.resolvers.ts
+++ b/test-expands/a-gens/ts/test-authentication.test-expected/src1/services/graphql/service.resolvers.ts
@@ -14,7 +14,7 @@ export interface ServiceResolverOptions {
 }
 
 let moduleExports = function serviceResolvers(app: App, options: ServiceResolverOptions) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -31,7 +31,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb2: Nedb2!
       nedb2:
         // !<DEFAULT> code: resolver-Nedb1-nedb2
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb2Id }, paginate: false
           });
@@ -45,7 +45,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb1: Nedb1!
       nedb1:
         // !<DEFAULT> code: resolver-Nedb2-nedb1
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb1Id }, paginate: false
           });
@@ -60,28 +60,28 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/a-gens/ts/test-hook-integ.test-expected/src1/app.interface.ts
+++ b/test-expands/a-gens/ts/test-hook-integ.test-expected/src1/app.interface.ts
@@ -19,14 +19,11 @@ import { Users1 } from './services/users-1/users-1.interface';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
-  'nedb-1': Nedb1;
-  'nedb-2': Nedb2;
-  'users-1': Users1;
+export type App = Application<{
+  'nedb-1': Nedb1,
+  'nedb-2': Nedb2,
+  'users-1': Users1,
   // !code: moduleExports // !end
-}
-
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/test-expands/a-gens/ts/test-hook-integ.test-expected/src1/app.ts
+++ b/test-expands/a-gens/ts/test-hook-integ.test-expected/src1/app.ts
@@ -10,10 +10,9 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
-import { Services } from './app.interface';
 import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
@@ -25,7 +24,7 @@ import authentication from './authentication';
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/test-expands/a-gens/ts/test-hook-integ.test-expected/src1/services/graphql/batchloader.resolvers.ts
+++ b/test-expands/a-gens/ts/test-hook-integ.test-expected/src1/services/graphql/batchloader.resolvers.ts
@@ -20,7 +20,7 @@ export interface BatchloaderResolverOptions {
 // !code: imports // !end
 // !code: init // !end
 
-let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions) {
+let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions ) {
   // tslint:disable-next-line
   let { convertArgsToParams, convertArgsToFeathers, extractAllItems, extractFirstItem,
     feathersBatchLoader: { feathersBatchLoader } } = options;
@@ -73,53 +73,53 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -147,28 +147,28 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/a-gens/ts/test-hook-integ.test-expected/src1/services/graphql/service.resolvers.ts
+++ b/test-expands/a-gens/ts/test-hook-integ.test-expected/src1/services/graphql/service.resolvers.ts
@@ -14,7 +14,7 @@ export interface ServiceResolverOptions {
 }
 
 let moduleExports = function serviceResolvers(app: App, options: ServiceResolverOptions) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -31,7 +31,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb2: Nedb2!
       nedb2:
         // !<DEFAULT> code: resolver-Nedb1-nedb2
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb2Id }, paginate: false
           });
@@ -45,7 +45,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb1: Nedb1!
       nedb1:
         // !<DEFAULT> code: resolver-Nedb2-nedb1
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb1Id }, paginate: false
           });
@@ -60,28 +60,28 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/a-gens/ts/test-hook-unit.test-expected/src1/app.interface.ts
+++ b/test-expands/a-gens/ts/test-hook-unit.test-expected/src1/app.interface.ts
@@ -19,14 +19,11 @@ import { Users1 } from './services/users-1/users-1.interface';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
-  'nedb-1': Nedb1;
-  'nedb-2': Nedb2;
-  'users-1': Users1;
+export type App = Application<{
+  'nedb-1': Nedb1,
+  'nedb-2': Nedb2,
+  'users-1': Users1,
   // !code: moduleExports // !end
-}
-
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/test-expands/a-gens/ts/test-hook-unit.test-expected/src1/app.ts
+++ b/test-expands/a-gens/ts/test-hook-unit.test-expected/src1/app.ts
@@ -10,10 +10,9 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
-import { Services } from './app.interface';
 import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
@@ -25,7 +24,7 @@ import authentication from './authentication';
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/test-expands/a-gens/ts/test-hook-unit.test-expected/src1/services/graphql/batchloader.resolvers.ts
+++ b/test-expands/a-gens/ts/test-hook-unit.test-expected/src1/services/graphql/batchloader.resolvers.ts
@@ -20,7 +20,7 @@ export interface BatchloaderResolverOptions {
 // !code: imports // !end
 // !code: init // !end
 
-let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions) {
+let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions ) {
   // tslint:disable-next-line
   let { convertArgsToParams, convertArgsToFeathers, extractAllItems, extractFirstItem,
     feathersBatchLoader: { feathersBatchLoader } } = options;
@@ -73,53 +73,53 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -147,28 +147,28 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/a-gens/ts/test-hook-unit.test-expected/src1/services/graphql/service.resolvers.ts
+++ b/test-expands/a-gens/ts/test-hook-unit.test-expected/src1/services/graphql/service.resolvers.ts
@@ -14,7 +14,7 @@ export interface ServiceResolverOptions {
 }
 
 let moduleExports = function serviceResolvers(app: App, options: ServiceResolverOptions) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -31,7 +31,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb2: Nedb2!
       nedb2:
         // !<DEFAULT> code: resolver-Nedb1-nedb2
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb2Id }, paginate: false
           });
@@ -45,7 +45,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb1: Nedb1!
       nedb1:
         // !<DEFAULT> code: resolver-Nedb2-nedb1
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb1Id }, paginate: false
           });
@@ -60,28 +60,28 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/a-gens/ts/test-service.test-expected/src1/app.interface.ts
+++ b/test-expands/a-gens/ts/test-service.test-expected/src1/app.interface.ts
@@ -19,14 +19,11 @@ import { Users1 } from './services/users-1/users-1.interface';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
-  'nedb-1': Nedb1;
-  'nedb-2': Nedb2;
-  'users-1': Users1;
+export type App = Application<{
+  'nedb-1': Nedb1,
+  'nedb-2': Nedb2,
+  'users-1': Users1,
   // !code: moduleExports // !end
-}
-
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/test-expands/a-gens/ts/test-service.test-expected/src1/app.ts
+++ b/test-expands/a-gens/ts/test-service.test-expected/src1/app.ts
@@ -10,10 +10,9 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
-import { Services } from './app.interface';
 import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
@@ -25,7 +24,7 @@ import authentication from './authentication';
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/test-expands/a-gens/ts/test-service.test-expected/src1/services/graphql/batchloader.resolvers.ts
+++ b/test-expands/a-gens/ts/test-service.test-expected/src1/services/graphql/batchloader.resolvers.ts
@@ -20,7 +20,7 @@ export interface BatchloaderResolverOptions {
 // !code: imports // !end
 // !code: init // !end
 
-let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions) {
+let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions ) {
   // tslint:disable-next-line
   let { convertArgsToParams, convertArgsToFeathers, extractAllItems, extractFirstItem,
     feathersBatchLoader: { feathersBatchLoader } } = options;
@@ -73,53 +73,53 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -147,28 +147,28 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/a-gens/ts/test-service.test-expected/src1/services/graphql/service.resolvers.ts
+++ b/test-expands/a-gens/ts/test-service.test-expected/src1/services/graphql/service.resolvers.ts
@@ -14,7 +14,7 @@ export interface ServiceResolverOptions {
 }
 
 let moduleExports = function serviceResolvers(app: App, options: ServiceResolverOptions) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -31,7 +31,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb2: Nedb2!
       nedb2:
         // !<DEFAULT> code: resolver-Nedb1-nedb2
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb2Id }, paginate: false
           });
@@ -45,7 +45,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb1: Nedb1!
       nedb1:
         // !<DEFAULT> code: resolver-Nedb2-nedb1
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb1Id }, paginate: false
           });
@@ -60,28 +60,28 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/a-specs/service-sequelize-mssql.test-expected/src1/app.js
+++ b/test-expands/a-specs/service-sequelize-mssql.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/app-code-blocks.test-expected/src1/app.js
+++ b/test-expands/app-code-blocks.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/app-eslintrc.test-expected/src1/app.js
+++ b/test-expands/app-eslintrc.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/app.test-expected/src1/app.js
+++ b/test-expands/app.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/authentication-1.test-expected/src1/app.js
+++ b/test-expands/authentication-1.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/authentication-2.test-expected/src1/app.js
+++ b/test-expands/authentication-2.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/authentication-3.test-expected/src1/app.js
+++ b/test-expands/authentication-3.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/cumulative-1-generic.test-expected/src1/app.js
+++ b/test-expands/cumulative-1-generic.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/cumulative-1-generic.test-expected/src1/services/graphql/batchloader.resolvers.js
+++ b/test-expands/cumulative-1-generic.test-expected/src1/services/graphql/batchloader.resolvers.js
@@ -54,53 +54,53 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -135,7 +135,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -149,7 +149,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/cumulative-1-generic.test-expected/src1/services/graphql/service.resolvers.js
+++ b/test-expands/cumulative-1-generic.test-expected/src1/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -28,7 +28,7 @@ let moduleExports = function serviceResolvers(app, options) {
           });
           return nedb2.find(feathersParams).then(extractFirstItem);
         },
-      // !end
+        // !end
     },
 
     Nedb2: {
@@ -42,7 +42,7 @@ let moduleExports = function serviceResolvers(app, options) {
           });
           return nedb1.find(feathersParams).then(extractFirstItem);
         },
-      // !end
+        // !end
     },
 
     // !code: resolver_field_more // !end
@@ -58,7 +58,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -72,7 +72,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/cumulative-1-memory.test-expected/src1/app.js
+++ b/test-expands/cumulative-1-memory.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/cumulative-1-memory.test-expected/src1/services/graphql/batchloader.resolvers.js
+++ b/test-expands/cumulative-1-memory.test-expected/src1/services/graphql/batchloader.resolvers.js
@@ -54,53 +54,53 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -135,7 +135,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -149,7 +149,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/cumulative-1-memory.test-expected/src1/services/graphql/service.resolvers.js
+++ b/test-expands/cumulative-1-memory.test-expected/src1/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -28,7 +28,7 @@ let moduleExports = function serviceResolvers(app, options) {
           });
           return nedb2.find(feathersParams).then(extractFirstItem);
         },
-      // !end
+        // !end
     },
 
     Nedb2: {
@@ -42,7 +42,7 @@ let moduleExports = function serviceResolvers(app, options) {
           });
           return nedb1.find(feathersParams).then(extractFirstItem);
         },
-      // !end
+        // !end
     },
 
     // !code: resolver_field_more // !end
@@ -58,7 +58,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -72,7 +72,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/cumulative-1-mongo.test-expected/src1/app.js
+++ b/test-expands/cumulative-1-mongo.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/cumulative-1-mongo.test-expected/src1/services/graphql/batchloader.resolvers.js
+++ b/test-expands/cumulative-1-mongo.test-expected/src1/services/graphql/batchloader.resolvers.js
@@ -54,53 +54,53 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -135,7 +135,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -149,7 +149,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/cumulative-1-mongo.test-expected/src1/services/graphql/service.resolvers.js
+++ b/test-expands/cumulative-1-mongo.test-expected/src1/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -28,7 +28,7 @@ let moduleExports = function serviceResolvers(app, options) {
           });
           return nedb2.find(feathersParams).then(extractFirstItem);
         },
-      // !end
+        // !end
     },
 
     Nedb2: {
@@ -42,7 +42,7 @@ let moduleExports = function serviceResolvers(app, options) {
           });
           return nedb1.find(feathersParams).then(extractFirstItem);
         },
-      // !end
+        // !end
     },
 
     // !code: resolver_field_more // !end
@@ -58,7 +58,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -72,7 +72,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/cumulative-1-mongoose.test-expected/src1/app.js
+++ b/test-expands/cumulative-1-mongoose.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/cumulative-1-mongoose.test-expected/src1/services/graphql/batchloader.resolvers.js
+++ b/test-expands/cumulative-1-mongoose.test-expected/src1/services/graphql/batchloader.resolvers.js
@@ -54,53 +54,53 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -135,7 +135,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -149,7 +149,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/cumulative-1-mongoose.test-expected/src1/services/graphql/service.resolvers.js
+++ b/test-expands/cumulative-1-mongoose.test-expected/src1/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -28,7 +28,7 @@ let moduleExports = function serviceResolvers(app, options) {
           });
           return nedb2.find(feathersParams).then(extractFirstItem);
         },
-      // !end
+        // !end
     },
 
     Nedb2: {
@@ -42,7 +42,7 @@ let moduleExports = function serviceResolvers(app, options) {
           });
           return nedb1.find(feathersParams).then(extractFirstItem);
         },
-      // !end
+        // !end
     },
 
     // !code: resolver_field_more // !end
@@ -58,7 +58,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -72,7 +72,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/cumulative-1-nedb.test-expected/src1/app.js
+++ b/test-expands/cumulative-1-nedb.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/cumulative-1-nedb.test-expected/src1/services/graphql/batchloader.resolvers.js
+++ b/test-expands/cumulative-1-nedb.test-expected/src1/services/graphql/batchloader.resolvers.js
@@ -54,53 +54,53 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -135,7 +135,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -149,7 +149,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/cumulative-1-nedb.test-expected/src1/services/graphql/service.resolvers.js
+++ b/test-expands/cumulative-1-nedb.test-expected/src1/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -28,7 +28,7 @@ let moduleExports = function serviceResolvers(app, options) {
           });
           return nedb2.find(feathersParams).then(extractFirstItem);
         },
-      // !end
+        // !end
     },
 
     Nedb2: {
@@ -42,7 +42,7 @@ let moduleExports = function serviceResolvers(app, options) {
           });
           return nedb1.find(feathersParams).then(extractFirstItem);
         },
-      // !end
+        // !end
     },
 
     // !code: resolver_field_more // !end
@@ -58,7 +58,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -72,7 +72,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/cumulative-1-no-semicolons.test-expected/src1/app.js
+++ b/test-expands/cumulative-1-no-semicolons.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration')
 const express = require('@feathersjs/express')
 const socketio = require('@feathersjs/socketio')
 
-
 const middleware = require('./middleware')
 const services = require('./services')
 const appHooks = require('./app.hooks')

--- a/test-expands/cumulative-1-no-semicolons.test-expected/src1/services/graphql/batchloader.resolvers.js
+++ b/test-expands/cumulative-1-no-semicolons.test-expected/src1/services/graphql/batchloader.resolvers.js
@@ -54,53 +54,53 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          })
+          return nedb2.find(feathersParams)
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      )
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          })
+          return nedb1.find(feathersParams)
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      )
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            })
-            return nedb2.find(feathersParams)
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        )
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            })
-            return nedb1.find(feathersParams)
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        )
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`)
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`)
       // !end
     }
   }
@@ -135,7 +135,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } })
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } })
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems)
       },
       // !end
@@ -149,7 +149,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } })
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } })
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems)
       },
       // !end

--- a/test-expands/cumulative-1-no-semicolons.test-expected/src1/services/graphql/service.resolvers.js
+++ b/test-expands/cumulative-1-no-semicolons.test-expected/src1/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([])
   // !end
@@ -28,7 +28,7 @@ let moduleExports = function serviceResolvers(app, options) {
           })
           return nedb2.find(feathersParams).then(extractFirstItem)
         },
-      // !end
+        // !end
     },
 
     Nedb2: {
@@ -42,7 +42,7 @@ let moduleExports = function serviceResolvers(app, options) {
           })
           return nedb1.find(feathersParams).then(extractFirstItem)
         },
-      // !end
+        // !end
     },
 
     // !code: resolver_field_more // !end
@@ -58,7 +58,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } })
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } })
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems)
       },
       // !end
@@ -72,7 +72,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } })
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } })
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems)
       },
       // !end

--- a/test-expands/cumulative-2-hooks.test-expected/src1/app.js
+++ b/test-expands/cumulative-2-hooks.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/cumulative-2-hooks.test-expected/src1/services/graphql/batchloader.resolvers.js
+++ b/test-expands/cumulative-2-hooks.test-expected/src1/services/graphql/batchloader.resolvers.js
@@ -54,53 +54,53 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -135,7 +135,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -149,7 +149,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/cumulative-2-hooks.test-expected/src1/services/graphql/service.resolvers.js
+++ b/test-expands/cumulative-2-hooks.test-expected/src1/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -28,7 +28,7 @@ let moduleExports = function serviceResolvers(app, options) {
           });
           return nedb2.find(feathersParams).then(extractFirstItem);
         },
-      // !end
+        // !end
     },
 
     Nedb2: {
@@ -42,7 +42,7 @@ let moduleExports = function serviceResolvers(app, options) {
           });
           return nedb1.find(feathersParams).then(extractFirstItem);
         },
-      // !end
+        // !end
     },
 
     // !code: resolver_field_more // !end
@@ -58,7 +58,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -72,7 +72,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/cumulative-2-nedb-batchloaders.test-expected/src1/app.js
+++ b/test-expands/cumulative-2-nedb-batchloaders.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/cumulative-2-nedb-batchloaders.test-expected/src1/services/graphql/batchloader.resolvers.js
+++ b/test-expands/cumulative-2-nedb-batchloaders.test-expected/src1/services/graphql/batchloader.resolvers.js
@@ -54,53 +54,53 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -135,7 +135,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -149,7 +149,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/cumulative-2-nedb-batchloaders.test-expected/src1/services/graphql/service.resolvers.js
+++ b/test-expands/cumulative-2-nedb-batchloaders.test-expected/src1/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -28,7 +28,7 @@ let moduleExports = function serviceResolvers(app, options) {
           });
           return nedb2.find(feathersParams).then(extractFirstItem);
         },
-      // !end
+        // !end
     },
 
     Nedb2: {
@@ -42,7 +42,7 @@ let moduleExports = function serviceResolvers(app, options) {
           });
           return nedb1.find(feathersParams).then(extractFirstItem);
         },
-      // !end
+        // !end
     },
 
     // !code: resolver_field_more // !end
@@ -58,7 +58,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -72,7 +72,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/cumulative-2-sequelize-services.test-expected/src1/app.js
+++ b/test-expands/cumulative-2-sequelize-services.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/cumulative-2-sequelize-services.test-expected/src1/services/graphql/batchloader.resolvers.js
+++ b/test-expands/cumulative-2-sequelize-services.test-expected/src1/services/graphql/batchloader.resolvers.js
@@ -54,53 +54,53 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', 'id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', 'id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', 'id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', 'id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -135,7 +135,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -149,7 +149,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/cumulative-2-sequelize-services.test-expected/src1/services/graphql/service.resolvers.js
+++ b/test-expands/cumulative-2-sequelize-services.test-expected/src1/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end

--- a/test-expands/graphql-auth.test-expected/src1/app.js
+++ b/test-expands/graphql-auth.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/graphql-auth.test-expected/src1/services/graphql/batchloader.resolvers.js
+++ b/test-expands/graphql-auth.test-expected/src1/services/graphql/batchloader.resolvers.js
@@ -54,53 +54,53 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -135,7 +135,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -149,7 +149,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/graphql-auth.test-expected/src1/services/graphql/service.resolvers.js
+++ b/test-expands/graphql-auth.test-expected/src1/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -58,7 +58,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -72,7 +72,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/graphql.test-expected/src1/app.js
+++ b/test-expands/graphql.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/graphql.test-expected/src1/services/graphql/batchloader.resolvers.js
+++ b/test-expands/graphql.test-expected/src1/services/graphql/batchloader.resolvers.js
@@ -54,53 +54,53 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -135,7 +135,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -149,7 +149,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/graphql.test-expected/src1/services/graphql/service.resolvers.js
+++ b/test-expands/graphql.test-expected/src1/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -58,7 +58,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -72,7 +72,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/middleware.test-expected/src1/app.js
+++ b/test-expands/middleware.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/name-space.test-expected/src1/app.js
+++ b/test-expands/name-space.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/regen-adapters-1.test-expected/src1/app.js
+++ b/test-expands/regen-adapters-1.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/regen-user-entity.test-expected/src1/app.js
+++ b/test-expands/regen-user-entity.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/scaffolding.test-expected/src1/app.js
+++ b/test-expands/scaffolding.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/service-naming.test-expected/src1/app.js
+++ b/test-expands/service-naming.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/service-naming.test-expected/src1/services/graphql/batchloader.resolvers.js
+++ b/test-expands/service-naming.test-expected/src1/services/graphql/batchloader.resolvers.js
@@ -54,53 +54,53 @@ let moduleExports = function batchLoaderResolvers(app, options) {
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        keys => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          keys => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -135,7 +135,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -149,7 +149,7 @@ let moduleExports = function batchLoaderResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/service-naming.test-expected/src1/services/graphql/service.resolvers.js
+++ b/test-expands/service-naming.test-expected/src1/services/graphql/service.resolvers.js
@@ -5,7 +5,7 @@
 // !code: init // !end
 
 let moduleExports = function serviceResolvers(app, options) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -58,7 +58,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
       findNedb1(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
@@ -72,7 +72,7 @@ let moduleExports = function serviceResolvers(app, options) {
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
       findNedb2(parent, args, content, ast) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/service.test-expected/src1/app.js
+++ b/test-expands/service.test-expected/src1/app.js
@@ -13,7 +13,6 @@ const configuration = require('@feathersjs/configuration');
 const express = require('@feathersjs/express');
 const socketio = require('@feathersjs/socketio');
 
-
 const middleware = require('./middleware');
 const services = require('./services');
 const appHooks = require('./app.hooks');

--- a/test-expands/ts-cumulative-1-generic.test-expected/src1/app.interface.ts
+++ b/test-expands/ts-cumulative-1-generic.test-expected/src1/app.interface.ts
@@ -19,13 +19,11 @@ import { Users1 } from './services/users-1/users-1.interface';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
-  'nedb-1': Nedb1;
-  'nedb-2': Nedb2;
-  'users-1': Users1;
+export type App = Application<{
+  'nedb-1': Nedb1,
+  'nedb-2': Nedb2,
+  'users-1': Users1,
   // !code: moduleExports // !end
-}
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/test-expands/ts-cumulative-1-generic.test-expected/src1/app.ts
+++ b/test-expands/ts-cumulative-1-generic.test-expected/src1/app.ts
@@ -10,10 +10,9 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
-import { Services } from './app.interface';
 import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
@@ -25,7 +24,7 @@ import authentication from './authentication';
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/test-expands/ts-cumulative-1-generic.test-expected/src1/services/graphql/batchloader.resolvers.ts
+++ b/test-expands/ts-cumulative-1-generic.test-expected/src1/services/graphql/batchloader.resolvers.ts
@@ -20,7 +20,7 @@ export interface BatchloaderResolverOptions {
 // !code: imports // !end
 // !code: init // !end
 
-let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions) {
+let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions ) {
   // tslint:disable-next-line
   let { convertArgsToParams, convertArgsToFeathers, extractAllItems, extractFirstItem,
     feathersBatchLoader: { feathersBatchLoader } } = options;
@@ -73,53 +73,53 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -147,28 +147,28 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/ts-cumulative-1-generic.test-expected/src1/services/graphql/service.resolvers.ts
+++ b/test-expands/ts-cumulative-1-generic.test-expected/src1/services/graphql/service.resolvers.ts
@@ -14,7 +14,7 @@ export interface ServiceResolverOptions {
 }
 
 let moduleExports = function serviceResolvers(app: App, options: ServiceResolverOptions) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -31,7 +31,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb2: Nedb2!
       nedb2:
         // !<DEFAULT> code: resolver-Nedb1-nedb2
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb2Id }, paginate: false
           });
@@ -45,7 +45,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb1: Nedb1!
       nedb1:
         // !<DEFAULT> code: resolver-Nedb2-nedb1
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb1Id }, paginate: false
           });
@@ -60,28 +60,28 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/ts-cumulative-1-memory.test-expected/src1/app.interface.ts
+++ b/test-expands/ts-cumulative-1-memory.test-expected/src1/app.interface.ts
@@ -19,14 +19,11 @@ import { Users1 } from './services/users-1/users-1.interface';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
-  'nedb-1': Nedb1;
-  'nedb-2': Nedb2;
-  'users-1': Users1;
+export type App = Application<{
+  'nedb-1': Nedb1,
+  'nedb-2': Nedb2,
+  'users-1': Users1,
   // !code: moduleExports // !end
-}
-
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/test-expands/ts-cumulative-1-memory.test-expected/src1/app.ts
+++ b/test-expands/ts-cumulative-1-memory.test-expected/src1/app.ts
@@ -10,10 +10,9 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
-import { Services } from './app.interface';
 import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
@@ -25,7 +24,7 @@ import authentication from './authentication';
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/test-expands/ts-cumulative-1-memory.test-expected/src1/services/graphql/batchloader.resolvers.ts
+++ b/test-expands/ts-cumulative-1-memory.test-expected/src1/services/graphql/batchloader.resolvers.ts
@@ -20,7 +20,7 @@ export interface BatchloaderResolverOptions {
 // !code: imports // !end
 // !code: init // !end
 
-let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions) {
+let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions ) {
   // tslint:disable-next-line
   let { convertArgsToParams, convertArgsToFeathers, extractAllItems, extractFirstItem,
     feathersBatchLoader: { feathersBatchLoader } } = options;
@@ -73,53 +73,53 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -147,28 +147,28 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/ts-cumulative-1-memory.test-expected/src1/services/graphql/service.resolvers.ts
+++ b/test-expands/ts-cumulative-1-memory.test-expected/src1/services/graphql/service.resolvers.ts
@@ -14,7 +14,7 @@ export interface ServiceResolverOptions {
 }
 
 let moduleExports = function serviceResolvers(app: App, options: ServiceResolverOptions) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -31,7 +31,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb2: Nedb2!
       nedb2:
         // !<DEFAULT> code: resolver-Nedb1-nedb2
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb2Id }, paginate: false
           });
@@ -45,7 +45,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb1: Nedb1!
       nedb1:
         // !<DEFAULT> code: resolver-Nedb2-nedb1
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb1Id }, paginate: false
           });
@@ -60,28 +60,28 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/ts-cumulative-1-mongo.test-expected/src1/app.interface.ts
+++ b/test-expands/ts-cumulative-1-mongo.test-expected/src1/app.interface.ts
@@ -19,14 +19,11 @@ import { Users1 } from './services/users-1/users-1.interface';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
-  'nedb-1': Nedb1;
-  'nedb-2': Nedb2;
-  'users-1': Users1;
+export type App = Application<{
+  'nedb-1': Nedb1,
+  'nedb-2': Nedb2,
+  'users-1': Users1,
   // !code: moduleExports // !end
-}
-
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/test-expands/ts-cumulative-1-mongo.test-expected/src1/app.ts
+++ b/test-expands/ts-cumulative-1-mongo.test-expected/src1/app.ts
@@ -10,10 +10,9 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
-import { Services } from './app.interface';
 import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
@@ -26,7 +25,7 @@ import mongodb from './mongodb';
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/test-expands/ts-cumulative-1-mongo.test-expected/src1/services/graphql/batchloader.resolvers.ts
+++ b/test-expands/ts-cumulative-1-mongo.test-expected/src1/services/graphql/batchloader.resolvers.ts
@@ -20,7 +20,7 @@ export interface BatchloaderResolverOptions {
 // !code: imports // !end
 // !code: init // !end
 
-let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions) {
+let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions ) {
   // tslint:disable-next-line
   let { convertArgsToParams, convertArgsToFeathers, extractAllItems, extractFirstItem,
     feathersBatchLoader: { feathersBatchLoader } } = options;
@@ -73,53 +73,53 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -147,28 +147,28 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/ts-cumulative-1-mongo.test-expected/src1/services/graphql/service.resolvers.ts
+++ b/test-expands/ts-cumulative-1-mongo.test-expected/src1/services/graphql/service.resolvers.ts
@@ -14,7 +14,7 @@ export interface ServiceResolverOptions {
 }
 
 let moduleExports = function serviceResolvers(app: App, options: ServiceResolverOptions) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -31,7 +31,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb2: Nedb2!
       nedb2:
         // !<DEFAULT> code: resolver-Nedb1-nedb2
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb2Id }, paginate: false
           });
@@ -45,7 +45,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb1: Nedb1!
       nedb1:
         // !<DEFAULT> code: resolver-Nedb2-nedb1
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb1Id }, paginate: false
           });
@@ -60,28 +60,28 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/ts-cumulative-1-mongoose.test-expected/src1/app.interface.ts
+++ b/test-expands/ts-cumulative-1-mongoose.test-expected/src1/app.interface.ts
@@ -19,14 +19,11 @@ import { Users1 } from './services/users-1/users-1.interface';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
-  'nedb-1': Nedb1;
-  'nedb-2': Nedb2;
-  'users-1': Users1;
+export type App = Application<{
+  'nedb-1': Nedb1,
+  'nedb-2': Nedb2,
+  'users-1': Users1,
   // !code: moduleExports // !end
-}
-
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/test-expands/ts-cumulative-1-mongoose.test-expected/src1/app.ts
+++ b/test-expands/ts-cumulative-1-mongoose.test-expected/src1/app.ts
@@ -10,7 +10,7 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
 import middleware from './middleware';
@@ -25,7 +25,7 @@ import mongoose from './mongoose';
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/graphql/batchloader.resolvers.ts
+++ b/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/graphql/batchloader.resolvers.ts
@@ -20,7 +20,7 @@ export interface BatchloaderResolverOptions {
 // !code: imports // !end
 // !code: init // !end
 
-let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions) {
+let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions ) {
   // tslint:disable-next-line
   let { convertArgsToParams, convertArgsToFeathers, extractAllItems, extractFirstItem,
     feathersBatchLoader: { feathersBatchLoader } } = options;
@@ -73,53 +73,53 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -147,28 +147,28 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/graphql/service.resolvers.ts
+++ b/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/graphql/service.resolvers.ts
@@ -14,7 +14,7 @@ export interface ServiceResolverOptions {
 }
 
 let moduleExports = function serviceResolvers(app: App, options: ServiceResolverOptions) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -31,7 +31,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb2: Nedb2!
       nedb2:
         // !<DEFAULT> code: resolver-Nedb1-nedb2
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb2Id }, paginate: false
           });
@@ -45,7 +45,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb1: Nedb1!
       nedb1:
         // !<DEFAULT> code: resolver-Nedb2-nedb1
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb1Id }, paginate: false
           });
@@ -60,28 +60,28 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/ts-cumulative-1-nedb.test-expected/src1/app.interface.ts
+++ b/test-expands/ts-cumulative-1-nedb.test-expected/src1/app.interface.ts
@@ -19,14 +19,11 @@ import { Users1 } from './services/users-1/users-1.interface';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
-  'nedb-1': Nedb1;
-  'nedb-2': Nedb2;
-  'users-1': Users1;
+export type App = Application<{
+  'nedb-1': Nedb1,
+  'nedb-2': Nedb2,
+  'users-1': Users1,
   // !code: moduleExports // !end
-}
-
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/test-expands/ts-cumulative-1-nedb.test-expected/src1/app.ts
+++ b/test-expands/ts-cumulative-1-nedb.test-expected/src1/app.ts
@@ -10,10 +10,9 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
-import { Services } from './app.interface';
 import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
@@ -25,7 +24,7 @@ import authentication from './authentication';
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/test-expands/ts-cumulative-1-nedb.test-expected/src1/services/graphql/batchloader.resolvers.ts
+++ b/test-expands/ts-cumulative-1-nedb.test-expected/src1/services/graphql/batchloader.resolvers.ts
@@ -20,7 +20,7 @@ export interface BatchloaderResolverOptions {
 // !code: imports // !end
 // !code: init // !end
 
-let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions) {
+let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions ) {
   // tslint:disable-next-line
   let { convertArgsToParams, convertArgsToFeathers, extractAllItems, extractFirstItem,
     feathersBatchLoader: { feathersBatchLoader } } = options;
@@ -73,53 +73,53 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -147,28 +147,28 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/ts-cumulative-1-nedb.test-expected/src1/services/graphql/service.resolvers.ts
+++ b/test-expands/ts-cumulative-1-nedb.test-expected/src1/services/graphql/service.resolvers.ts
@@ -14,7 +14,7 @@ export interface ServiceResolverOptions {
 }
 
 let moduleExports = function serviceResolvers(app: App, options: ServiceResolverOptions) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -31,7 +31,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb2: Nedb2!
       nedb2:
         // !<DEFAULT> code: resolver-Nedb1-nedb2
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb2Id }, paginate: false
           });
@@ -45,7 +45,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb1: Nedb1!
       nedb1:
         // !<DEFAULT> code: resolver-Nedb2-nedb1
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb1Id }, paginate: false
           });
@@ -60,28 +60,28 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/ts-cumulative-2-hooks.test-expected/src1/app.interface.ts
+++ b/test-expands/ts-cumulative-2-hooks.test-expected/src1/app.interface.ts
@@ -19,14 +19,11 @@ import { Users1 } from './services/users-1/users-1.interface';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
-  'nedb-1': Nedb1;
-  'nedb-2': Nedb2;
-  'users-1': Users1;
+export type App = Application<{
+  'nedb-1': Nedb1,
+  'nedb-2': Nedb2,
+  'users-1': Users1,
   // !code: moduleExports // !end
-}
-
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/test-expands/ts-cumulative-2-hooks.test-expected/src1/app.ts
+++ b/test-expands/ts-cumulative-2-hooks.test-expected/src1/app.ts
@@ -10,10 +10,9 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
-import { Services } from './app.interface';
 import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
@@ -25,7 +24,7 @@ import authentication from './authentication';
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/test-expands/ts-cumulative-2-hooks.test-expected/src1/services/graphql/batchloader.resolvers.ts
+++ b/test-expands/ts-cumulative-2-hooks.test-expected/src1/services/graphql/batchloader.resolvers.ts
@@ -20,7 +20,7 @@ export interface BatchloaderResolverOptions {
 // !code: imports // !end
 // !code: init // !end
 
-let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions) {
+let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions ) {
   // tslint:disable-next-line
   let { convertArgsToParams, convertArgsToFeathers, extractAllItems, extractFirstItem,
     feathersBatchLoader: { feathersBatchLoader } } = options;
@@ -73,53 +73,53 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', '_id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { _id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', '_id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { _id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -147,28 +147,28 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/ts-cumulative-2-hooks.test-expected/src1/services/graphql/service.resolvers.ts
+++ b/test-expands/ts-cumulative-2-hooks.test-expected/src1/services/graphql/service.resolvers.ts
@@ -14,7 +14,7 @@ export interface ServiceResolverOptions {
 }
 
 let moduleExports = function serviceResolvers(app: App, options: ServiceResolverOptions) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -31,7 +31,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb2: Nedb2!
       nedb2:
         // !<DEFAULT> code: resolver-Nedb1-nedb2
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb2Id }, paginate: false
           });
@@ -45,7 +45,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb1: Nedb1!
       nedb1:
         // !<DEFAULT> code: resolver-Nedb2-nedb1
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { _id: parent.nedb1Id }, paginate: false
           });
@@ -60,28 +60,28 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/ts-cumulative-2-sequelize-services.test-expected/src1/app.interface.ts
+++ b/test-expands/ts-cumulative-2-sequelize-services.test-expected/src1/app.interface.ts
@@ -19,14 +19,11 @@ import { Users1 } from './services/users-1/users-1.interface';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
-  'nedb-1': Nedb1;
-  'nedb-2': Nedb2;
-  'users-1': Users1;
+export type App = Application<{
+  'nedb-1': Nedb1,
+  'nedb-2': Nedb2,
+  'users-1': Users1,
   // !code: moduleExports // !end
-}
-
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/test-expands/ts-cumulative-2-sequelize-services.test-expected/src1/app.ts
+++ b/test-expands/ts-cumulative-2-sequelize-services.test-expected/src1/app.ts
@@ -10,10 +10,9 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
-import { Services } from './app.interface';
 import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
@@ -26,7 +25,7 @@ import sequelize from './sequelize';
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/test-expands/ts-cumulative-2-sequelize-services.test-expected/src1/services/graphql/batchloader.resolvers.ts
+++ b/test-expands/ts-cumulative-2-sequelize-services.test-expected/src1/services/graphql/batchloader.resolvers.ts
@@ -20,7 +20,7 @@ export interface BatchloaderResolverOptions {
 // !code: imports // !end
 // !code: init // !end
 
-let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions) {
+let moduleExports = function batchLoaderResolvers(app: App, options: BatchloaderResolverOptions ) {
   // tslint:disable-next-line
   let { convertArgsToParams, convertArgsToFeathers, extractAllItems, extractFirstItem,
     feathersBatchLoader: { feathersBatchLoader } } = options;
@@ -73,53 +73,53 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
     let feathersParams;
 
     switch (dataLoaderName) {
-      /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
-      // !<DEFAULT> code: bl-persisted
-      // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    /* Persistent BatchLoaders. Stored in `content.batchLoaders._persisted`. */
+    // !<DEFAULT> code: bl-persisted
+    // case '_persisted.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
+    // !<DEFAULT> code: bl-shared
+    // *.*: User
+    // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // !end
+
+    /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
+
+    // Nedb1.nedb2: Nedb2!
+    // !<DEFAULT> code: bl-Nedb1-nedb2
+    case 'Nedb1.nedb2':
+      return feathersBatchLoader(dataLoaderName, '!', 'id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb2.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders shared among resolvers. Stored in `content.batchLoaders._shared`. */
-      // !<DEFAULT> code: bl-shared
-      // *.*: User
-      // case '_shared.user.one.id': // service user, returns one object, key is field id
+    // Nedb2.nedb1: Nedb1!
+    // !<DEFAULT> code: bl-Nedb2-nedb1
+    case 'Nedb2.nedb1':
+      return feathersBatchLoader(dataLoaderName, '!', 'id',
+        (keys: string[]) => {
+          feathersParams = convertArgs(args, content, null, {
+            query: { id: { $in: keys }, $sort: undefined },
+            _populate: 'skip', paginate: false
+          });
+          return nedb1.find(feathersParams);
+        },
+        maxBatchSize // Max #keys in a BatchLoader func call.
+      );
       // !end
 
-      /* Transient BatchLoaders used by only one resolver. Stored in `content.batchLoaders`. */
-
-      // Nedb1.nedb2: Nedb2!
-      // !<DEFAULT> code: bl-Nedb1-nedb2
-      case 'Nedb1.nedb2':
-        return feathersBatchLoader(dataLoaderName, '!', 'id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb2.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      // Nedb2.nedb1: Nedb1!
-      // !<DEFAULT> code: bl-Nedb2-nedb1
-      case 'Nedb2.nedb1':
-        return feathersBatchLoader(dataLoaderName, '!', 'id',
-          (keys: string[]) => {
-            feathersParams = convertArgs(args, content, null, {
-              query: { id: { $in: keys }, $sort: undefined },
-              _populate: 'skip', paginate: false
-            });
-            return nedb1.find(feathersParams);
-          },
-          maxBatchSize // Max #keys in a BatchLoader func call.
-        );
-      // !end
-
-      /* Throw on unknown BatchLoader name. */
-      default:
-        // !<DEFAULT> code: bl-default
-        throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
+    /* Throw on unknown BatchLoader name. */
+    default:
+      // !<DEFAULT> code: bl-default
+      throw new Error(`GraphQL query requires BatchLoader named '${dataLoaderName}' but no definition exists for it.`);
       // !end
     }
   }
@@ -147,28 +147,28 @@ let moduleExports = function batchLoaderResolvers(app: App, options: Batchloader
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { id: 1 } } });
+      findNedb1(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
-        const feathersParams = convertArgs(args, content, ast, { query: { $sort: { id: 1 } } });
+      findNedb2(parent, args, content, ast) {
+        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
       // !end

--- a/test-expands/ts-cumulative-2-sequelize-services.test-expected/src1/services/graphql/service.resolvers.ts
+++ b/test-expands/ts-cumulative-2-sequelize-services.test-expected/src1/services/graphql/service.resolvers.ts
@@ -14,7 +14,7 @@ export interface ServiceResolverOptions {
 }
 
 let moduleExports = function serviceResolvers(app: App, options: ServiceResolverOptions) {
-  const { convertArgsToFeathers, extractAllItems, extractFirstItem } = options;
+  const {convertArgsToFeathers, extractAllItems, extractFirstItem} = options;
   // !<DEFAULT> code: extra_auth_props
   const convertArgs = convertArgsToFeathers([]);
   // !end
@@ -31,7 +31,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb2: Nedb2!
       nedb2:
         // !<DEFAULT> code: resolver-Nedb1-nedb2
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { id: parent.nedb2Id }, paginate: false
           });
@@ -45,7 +45,7 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
       // nedb1: Nedb1!
       nedb1:
         // !<DEFAULT> code: resolver-Nedb2-nedb1
-        (parent: any, args: any, content: any, ast: any) => {
+        (parent, args, content, ast) => {
           const feathersParams = convertArgs(args, content, ast, {
             query: { id: parent.nedb1Id }, paginate: false
           });
@@ -60,13 +60,13 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-Nedb1
       // getNedb1(query: JSON, params: JSON, key: JSON): Nedb1
-      getNedb1(parent: any, args: any, content: any, ast: any) {
+      getNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb1.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb1(query: JSON, params: JSON): [Nedb1!]
-      findNedb1(parent: any, args: any, content: any, ast: any) {
+      findNedb1(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   id: 1 } } });
         return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },
@@ -74,13 +74,13 @@ let moduleExports = function serviceResolvers(app: App, options: ServiceResolver
 
       // !<DEFAULT> code: query-Nedb2
       // getNedb2(query: JSON, params: JSON, key: JSON): Nedb2
-      getNedb2(parent: any, args: any, content: any, ast: any) {
+      getNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast);
         return nedb2.get(args.key, feathersParams).then(extractFirstItem);
       },
 
       // findNedb2(query: JSON, params: JSON): [Nedb2!]
-      findNedb2(parent: any, args: any, content: any, ast: any) {
+      findNedb2(parent, args, content, ast) {
         const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   id: 1 } } });
         return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
       },

--- a/test-expands/ts-name-space.test-expected/src1/app.interface.ts
+++ b/test-expands/ts-name-space.test-expected/src1/app.interface.ts
@@ -22,17 +22,14 @@ import { Nedb6 } from './services/c-1/nedb-6/nedb-6.interface';
     user = 5; // this won't compile, because user is known to be of type User
   });
  */
-
-export interface Services {
-  'nedb-1': Nedb1;
-  'nedb-2': Nedb2;
-  'nedb-3': Nedb3;
-  'nedb-4': Nedb4;
-  'nedb-5': Nedb5;
-  'nedb-6': Nedb6;
+export type App = Application<{
+  'nedb-1': Nedb1,
+  'nedb-2': Nedb2,
+  'nedb-3': Nedb3,
+  'nedb-4': Nedb4,
+  'nedb-5': Nedb5,
+  'nedb-6': Nedb6,
   // !code: moduleExports // !end
-}
-
-export type App = Application<Services>;
+}>;
 // !code: funcs // !end
 // !code: end // !end

--- a/test-expands/ts-name-space.test-expected/src1/app.ts
+++ b/test-expands/ts-name-space.test-expected/src1/app.ts
@@ -10,10 +10,9 @@ import logger from './logger';
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
-import express, { Application } from '@feathersjs/express';
+import express from '@feathersjs/express';
 import socketio from '@feathersjs/socketio';
 
-import { Services } from './app.interface';
 import middleware from './middleware';
 import services from './services';
 import appHooks from './app.hooks';
@@ -24,7 +23,7 @@ const generatorSpecs = require('../feathers-gen-specs.json');
 // !code: imports // !end
 // !code: init // !end
 
-const app = express<Services>(feathers() as Application<Services>);
+const app = express(feathers());
 // !code: use_start // !end
 
 // Load app configuration

--- a/test/service-specs-to-mongoose.test.js
+++ b/test/service-specs-to-mongoose.test.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const usersSchema = require('./helpers/users.schema-enum');
 const moviesSchema = require('./helpers/movie.schema-default');
 
+
 describe('Creates Mongoose Schemas', function () {
   it('includes enum attributes', function () {
     const mongooseSchema = serviceSpecsToMongoose(usersSchema.schema);
@@ -17,14 +18,15 @@ describe('Creates Mongoose Schemas', function () {
   it('includes default attributes', function () {
     const mongooseSchema = serviceSpecsToMongoose(moviesSchema.schema);
 
-    assert.deepEqual(mongooseSchema.status.default, 'active', 'staus default value was correctly applied');
+    assert.deepEqual(mongooseSchema.status.default,'active', 'staus default value was correctly applied');
 
-    assert.deepEqual(mongooseSchema.genre.default, 'action', 'genre default value was correctly applied');
-
+    assert.deepEqual(mongooseSchema.genre.default,'action', 'genre default value was correctly applied');
+    
     assert.deepEqual(mongooseSchema.registerdDate.default, Date.now, 'registerdDate default value was correctly applied');
+   
   });
   it('properly generates model for array of objects', function () {
     const mongooseSchema = serviceSpecsToMongoose(usersSchema.schema);
-    assert.deepEqual(mongooseSchema.categories, [], 'categories ');
+    assert.deepEqual(mongooseSchema.categories, [], 'categories ')
   });
 });

--- a/test/z-generators-writing.test.js
+++ b/test/z-generators-writing.test.js
@@ -36,8 +36,7 @@ const tests = [
   // t0, z0 Test scaffolding to execute multiple generate calls and check the final result.
   // Also test a missing specs.options is created.
   //  generate app            # z-1, Project z-1, npm, src1, REST and socketio
-  {
-    testName: 'scaffolding.test',
+  { testName: 'scaffolding.test',
     specsChanges: [
       { generate: 'all', before: specs => delete specs.app.providers, merge: { app: { providers: ['primus'] } } },
       { generate: 'all', before: specs => delete specs.app.providers, merge: { app: { providers: ['rest'] } } },
@@ -45,25 +44,25 @@ const tests = [
       { generate: 'all', prompts: { confirmation: true } }
     ],
     compareDirs: true,
-    execute: false
+    execute: false,
   },
 
   // t01, z01 Test creation of app.
   //  generate app            # z-1, Project z-1, npm, src1, socketio (only)
-  { testName: 'app.test' },
+    { testName: 'app.test' },
 
   // Test when .eslintrc.json file already exists
-  { testName: 'app-eslintrc.test' },
+    { testName: 'app-eslintrc.test' },
 
   // Test using feathers-gen-code.js for code
-  { testName: 'app-code-blocks.test' },
+    { testName: 'app-code-blocks.test' },
 
   // t02, z02 (z01 ->) Test service creation without authentication scaffolding.
   // Also test any missing specs.options props are created.
   //* generate app            # z-1, Project z-1, npm, src1, socketio (only)
   //  generate service        # NeDB, nedb1, /nedb-1, nedb://../data, auth N, graphql Y
   //  generate service        # NeDB, nedb2, /nedb-2,                 auth N, graphql Y
-  { testName: 'service.test' },
+    { testName: 'service.test' },
 
   // t03, z03 (z02 ->) Test middleware creation.
   //* generate app            # z-1, Project z-1, npm, src1, socketio (only)
@@ -71,7 +70,7 @@ const tests = [
   //* generate service        # NeDB, nedb2, /nedb-2,                 auth N, graphql Y
   //  generate middleware     # mw1, *
   //  generate middleware     # mw2, mw2
-  { testName: 'middleware.test' },
+    { testName: 'middleware.test' },
 
   // t04, z04 (z02 ->) Test graphql endpoint creation.
   //* generate app            # z-1, Project z-1, npm, src1, socketio (only)
@@ -81,7 +80,7 @@ const tests = [
   //  Add schemas for nedb1 and nedb2
   //  Regenerate nedb1 and nedb2
   //  generate graphql        # service calls, /graphql,
-  { testName: 'graphql.test' },
+    { testName: 'graphql.test' },
 
   // (z04 ->) Test graphql endpoint creation with authentication.
   //* generate app            # z-1, Project z-1, npm, src1, socketio (only)
@@ -92,25 +91,25 @@ const tests = [
   //  Add schemas for nedb1 and nedb2
   //  Regenerate nedb1 and nedb2
   //  generate graphql        # service calls, /graphql,
-  { testName: 'graphql-auth.test' },
+    { testName: 'graphql-auth.test' },
 
   // t05, z05 Test authentication scaffolding.
   //  generate app            # z-1, Project z-1, npm, src1, REST and socketio
   //  generate authentication # Local and Auth0, users1, Nedb, nedb://../data, graphql Y
-  { testName: 'authentication-1.test' },
+    { testName: 'authentication-1.test' },
 
   // t06, z06 (z05 ->) Test creation of authenticated service with auth scaffolding.
   //* generate app            # z-1, Project z-1, npm, src1, REST and socketio
   //* generate authentication # Local and Auth0, users1, Nedb, nedb://../data, graphql Y
   //  generate service        # NeDB, nedb1, /nedb-1, nedb://../data, auth Y, graphql Y
-  { testName: 'authentication-2.test' },
+    { testName: 'authentication-2.test' },
 
   // t07, z07 (z06 ->) Test creation of non-authenticated service with auth scaffolding.
   //* generate app            # z-1, Project z-1, npm, src1, REST and socketio
   //* generate authentication # Local and Auth0, users1, Nedb, nedb://../data, graphql Y
   //* generate service        # NeDB, nedb1, /nedb-1, nedb://../data, auth Y, graphql Y
   //  generate service        # NeDB, nedb2, /nedb-2, nedb://../data, auth N, graphql Y
-  { testName: 'authentication-3.test' },
+    { testName: 'authentication-3.test' },
 
   // t08, z08 Test everything together. Mainly used to test different adapters.
   //  generate app            # z-1, Project z-1, npm, src1, REST and socketio
@@ -124,7 +123,7 @@ const tests = [
   //  Add schemas for users1, nedb1 and nedb2 --> ADD BOTH schema.properties AND extensions <--
   //  Regenerate users1, nedb1 and nedb2
   //  generate graphql        # service calls, /graphql, auth N
-  { testName: 'cumulative-1-nedb.test' },
+    { testName: 'cumulative-1-nedb.test' },
 
   // t08, z08 Test everything together. Mainly used to test different adapters.
   //  generate app            # z-1, Project z-1, npm, src1, REST and socketio
@@ -138,86 +137,82 @@ const tests = [
   //  Add schemas for users1, nedb1 and nedb2 --> ADD BOTH schema.properties AND extensions <--
   //  Regenerate users1, nedb1 and nedb2
   //  generate graphql        # service calls, /graphql, auth N
-  { testName: 'cumulative-1-generic.test' },
+    { testName: 'cumulative-1-generic.test' },
 
   // t08-memory, z08-memory The same as t08 & z08 but using @f/memory.
   // Service names remain nedb1 & nedb2.
-  { testName: 'cumulative-1-memory.test' },
+    { testName: 'cumulative-1-memory.test' },
 
   // t08-mongo, z08-mongo The same as t08 & z08 but using @f/mongodb.
   // Service names remain nedb1 & nedb2; use default connection string.
-  { testName: 'cumulative-1-mongo.test' },
+    { testName: 'cumulative-1-mongo.test' },
 
   // t08-mongoose, z08-mongoose The same as t08 & z08 but using @f/mongoosedb.
   // Service names remain nedb1 & nedb2; use default connection string.
-  { testName: 'cumulative-1-mongoose.test' },
+    { testName: 'cumulative-1-mongoose.test' },
 
   // The same as t08 & z08 but using options: { semicolons: false }
-  { testName: 'cumulative-1-no-semicolons.test' },
+    { testName: 'cumulative-1-no-semicolons.test' },
 
   // t08-sequelize, z08-sequelize The same as t08 & z08 but using @f/sequelize & PostgreSQL.
   // Service names remain nedb1 & nedb2; use default connection string.
-  { testName: 'cumulative-2-sequelize-services.test' },
+    { testName: 'cumulative-2-sequelize-services.test' },
 
   // The same as t08 & z08 but using options: { graphql: { strategy: 'batchloaders' } }
   // Service names remain nedb1 & nedb2; use default connection string.
-  { testName: 'cumulative-2-nedb-batchloaders.test' },
+    { testName: 'cumulative-2-nedb-batchloaders.test' },
 
   // Test hook generation with associated tests
-  { testName: 'cumulative-2-hooks.test' },
+    { testName: 'cumulative-2-hooks.test' },
 
   // Test generating unit hook tests
-  {
-    testName: 'a-gens/js/test-hook-unit.test',
-    specsChanges: [
-      { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.app1' } },
-      { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.nedb12' } },
-      { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.manual' } },
-      { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.nedb1' } },
-      { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.nedb2' } }
-    ],
-    compareDirs: true,
-    execute: false
-  },
+    { testName: 'a-gens/js/test-hook-unit.test',
+      specsChanges: [
+        { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.app1' } },
+        { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.nedb12' } },
+        { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.manual' } },
+        { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.nedb1' } },
+        { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.nedb2' } },
+      ],
+      compareDirs: true,
+      execute: false,
+    },
 
   // Test generating integration hook tests
-  {
-    testName: 'a-gens/js/test-hook-integ.test',
-    specsChanges: [
-      { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.app1' } },
-      { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.nedb12' } },
-      { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.manual' } },
-      { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.nedb1' } },
-      { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.nedb2' } }
-    ],
-    compareDirs: true,
-    execute: false
-  },
+    { testName: 'a-gens/js/test-hook-integ.test',
+      specsChanges: [
+        { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.app1' } },
+        { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.nedb12' } },
+        { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.manual' } },
+        { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.nedb1' } },
+        { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.nedb2' } },
+      ],
+      compareDirs: true,
+      execute: false,
+    },
 
   // Test generating service tests
-  {
-    testName: 'a-gens/js/test-service.test',
-    specsChanges: [
-      { generate: 'test', prompts: { testType: 'serviceUnit', serviceName: 'nedb1' } },
-      { generate: 'test', prompts: { testType: 'serviceUnit', serviceName: 'nedb2' } },
-      { generate: 'test', prompts: { testType: 'serviceInteg', serviceName: 'nedb1' } },
-      { generate: 'test', prompts: { testType: 'serviceInteg', serviceName: 'users1' } }
-    ],
-    compareDirs: true,
-    execute: false
-  },
+    { testName: 'a-gens/js/test-service.test',
+      specsChanges: [
+        { generate: 'test', prompts: { testType: 'serviceUnit', serviceName: 'nedb1' } },
+        { generate: 'test', prompts: { testType: 'serviceUnit', serviceName: 'nedb2' } },
+        { generate: 'test', prompts: { testType: 'serviceInteg', serviceName: 'nedb1' } },
+        { generate: 'test', prompts: { testType: 'serviceInteg', serviceName: 'users1' } },
+      ],
+      compareDirs: true,
+      execute: false,
+    },
 
   // Test generating authentication tests
   // Its tests TEST AUTHENTICATION and should be periodically run with dependency loading
-  {
-    testName: 'a-gens/js/test-authentication.test',
-    specsChanges: [
-      { generate: 'test', prompts: { testType: 'authBase' } },
-      { generate: 'test', prompts: { testType: 'authServices' } }
-    ],
-    compareDirs: true,
-    execute: false
-  },
+    { testName: 'a-gens/js/test-authentication.test',
+      specsChanges: [
+        { generate: 'test', prompts: { testType: 'authBase' } },
+        { generate: 'test', prompts: { testType: 'authServices' } },
+      ],
+      compareDirs: true,
+      execute: false,
+    },
 
   // t21, z21 Test switching the user-entity
   // t21
@@ -232,813 +227,673 @@ const tests = [
   //  generate authentication # Local+Auth0+Google+Facebook+GitHub,
   //                            users1, Nedb, /users-1, nedb://../data, auth Y, graphql N
   //  generate service        # NeDB, nedb1, /nedb-1, auth Y (line not needed in test as test regens whole app)
-  {
-    testName: 'regen-user-entity.test',
-    specsChanges: [
-      {
-        generate: 'all',
-        merge: {
-          authentication: { entity: 'users1' },
-          services: {
-            nedb1: { isAuthEntity: false },
-            users1: {
-              name: 'users1',
-              nameSingular: 'users1',
-              subFolder: '',
-              fileName: 'users-1',
-              adapter: 'nedb',
-              path: '/users-1',
-              isAuthEntity: true,
-              requiresAuth: true,
-              graphql: false
+    { testName: 'regen-user-entity.test',
+      specsChanges: [
+        { generate: 'all', merge: {
+            authentication: { entity: 'users1' },
+            services: {
+              nedb1: { isAuthEntity: false },
+              users1: {
+                name: 'users1',
+                nameSingular: 'users1',
+                subFolder: '',
+                fileName: 'users-1',
+                adapter: 'nedb',
+                path: '/users-1',
+                isAuthEntity: true,
+                requiresAuth: true,
+                graphql: false
+              },
             }
-          }
-        }
-      }
-    ]
-  },
+          } },
+      ]
+    },
 
   // z22 Test that app.js does not require templates/src/_adapters/* unless they are currently being used.
   // Also tests that existing package.json, config/default.json & config/production.json contents are retained.
   //  generate app            # z-1, Project z-1, npm, src1, socketio (only)
   //  generate service        # MongoDB, nedb1, /nedb-1, mongodb://localhost:27017/z_1, auth N, graphql Y
   //  generate service        # NeDB,    nedb1, /nedb-1, nedb://../data,                auth N, graphql Y
-  {
-    testName: 'regen-adapters-1.test',
-    specsChanges: [
-      {
-        generate: 'all',
-        merge: {
-          services: { nedb1: { adapter: 'nedb' } },
-          connections: {
-            'nedb': {
-              database: 'nedb',
-              adapter: 'nedb',
-              connectionString: 'nedb://../data'
+    { testName: 'regen-adapters-1.test',
+      specsChanges: [
+        { generate: 'all', merge: {
+            services: { nedb1: { adapter: 'nedb' } },
+            connections: {
+              'nedb': {
+                database: 'nedb',
+                adapter: 'nedb',
+                connectionString: 'nedb://../data'
+              }
             }
-          }
-        }
-      }
-    ]
-  },
+          } },
+      ]
+    },
 
   // test service in sub-folders
-  { testName: 'name-space.test' },
+    { testName: 'name-space.test' },
 
   // test old and new service folder/file naming
-  { testName: 'service-naming.test' }, // execute: true
+    { testName: 'service-naming.test' }, // execute: true
 
   // .ts version of cconst logger = require('./logger')umulative-1-nedb.test
-  { testName: 'ts-cumulative-1-nedb.test' },
+    { testName: 'ts-cumulative-1-nedb.test' },
 
   // .ts version of cumulative-1-generic.test
-  { testName: 'ts-cumulative-1-generic.test' },
+    { testName: 'ts-cumulative-1-generic.test' },
 
   // .ts version of cumulative-1-memory.test
-  { testName: 'ts-cumulative-1-memory.test' },
+    { testName: 'ts-cumulative-1-memory.test' },
 
   // .ts version of cumulative-1-mongo.test
-  { testName: 'ts-cumulative-1-mongo.test' },
+    { testName: 'ts-cumulative-1-mongo.test' },
 
   // .ts version of cumulative-1-mongoose.test
-  { testName: 'ts-cumulative-1-mongoose.test' },
+    { testName: 'ts-cumulative-1-mongoose.test' },
 
   // .ts version of cumulative-2-sequelize-services.test
-  { testName: 'ts-cumulative-2-sequelize-services.test' },
+    { testName: 'ts-cumulative-2-sequelize-services.test' },
 
   // Test hook generation with associated tests
-  { testName: 'ts-cumulative-2-hooks.test' },
+    { testName: 'ts-cumulative-2-hooks.test' },
 
   // Test generating unit hook tests
-  {
-    testName: 'a-gens/ts/test-hook-unit.test',
-    specsChanges: [
-      { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.app1' } },
-      { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.nedb12' } },
-      { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.manual' } },
-      { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.nedb1' } },
-      { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.nedb2' } }
-    ],
-    compareDirs: true,
-    execute: false
-  },
+    { testName: 'a-gens/ts/test-hook-unit.test',
+      specsChanges: [
+        { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.app1' } },
+        { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.nedb12' } },
+        { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.manual' } },
+        { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.nedb1' } },
+        { generate: 'test', prompts: { testType: 'hookUnit', hookName: 'hook.nedb2' } },
+      ],
+      compareDirs: true,
+      execute: false,
+    },
 
   // Test generating integration hook tests
-  {
-    testName: 'a-gens/ts/test-hook-integ.test',
-    specsChanges: [
-      { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.app1' } },
-      { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.nedb12' } },
-      { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.manual' } },
-      { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.nedb1' } },
-      { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.nedb2' } }
-    ],
-    compareDirs: true,
-    execute: false
-  },
+    { testName: 'a-gens/ts/test-hook-integ.test',
+      specsChanges: [
+        { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.app1' } },
+        { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.nedb12' } },
+        { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.manual' } },
+        { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.nedb1' } },
+        { generate: 'test', prompts: { testType: 'hookInteg', hookName: 'hook.nedb2' } },
+      ],
+      compareDirs: true,
+      execute: false,
+    },
 
   // Test generating service tests
-  {
-    testName: 'a-gens/ts/test-service.test',
-    specsChanges: [
-      { generate: 'test', prompts: { testType: 'serviceUnit', serviceName: 'nedb1' } },
-      { generate: 'test', prompts: { testType: 'serviceUnit', serviceName: 'nedb2' } },
-      { generate: 'test', prompts: { testType: 'serviceInteg', serviceName: 'nedb1' } },
-      { generate: 'test', prompts: { testType: 'serviceInteg', serviceName: 'users1' } }
-    ],
-    compareDirs: true,
-    execute: false
-  },
+    { testName: 'a-gens/ts/test-service.test',
+      specsChanges: [
+        { generate: 'test', prompts: { testType: 'serviceUnit', serviceName: 'nedb1' } },
+        { generate: 'test', prompts: { testType: 'serviceUnit', serviceName: 'nedb2' } },
+        { generate: 'test', prompts: { testType: 'serviceInteg', serviceName: 'nedb1' } },
+        { generate: 'test', prompts: { testType: 'serviceInteg', serviceName: 'users1' } },
+      ],
+      compareDirs: true,
+      execute: false,
+    },
 
   // Test generating authentication tests
-  {
-    testName: 'a-gens/ts/test-authentication.test',
-    specsChanges: [
-      { generate: 'test', prompts: { testType: 'authBase' } },
-      { generate: 'test', prompts: { testType: 'authServices' } }
-    ],
-    compareDirs: true,
-    execute: false
-  },
+    { testName: 'a-gens/ts/test-authentication.test',
+      specsChanges: [
+        { generate: 'test', prompts: { testType: 'authBase' } },
+        { generate: 'test', prompts: { testType: 'authServices' } },
+      ],
+      compareDirs: true,
+      execute: false,
+    },
 
   // test service in sub-folders
-  { testName: 'ts-name-space.test' },
+    { testName: 'ts-name-space.test' },
 
   // Test specs created by generator prompts
-  {
-    testName: 'a-specs/connection-memory.test',
-    specsChanges: [
-      {
-        generate: 'connection',
-        prompts: { database: 'memory' },
-        calledByTest: { prompts: { database: 'memory' } }
-      }
-    ],
-    compareOnlySpecs: true
-  },
-
-  {
-    testName: 'a-specs/connection-mongodb-mongodb.test',
-    specsChanges: [
-      {
-        generate: 'connection',
-        prompts: { database: 'mongodb', adapter: 'mongodb', connectionString: 'mongodb://localhost:27017/zz' },
-        calledByTest: {
-          prompts: { database: 'mongodb', adapter: 'mongodb', connectionString: 'mongodb://localhost:27017/zz' }
+    { testName: 'a-specs/connection-memory.test',
+      specsChanges: [
+        { generate: 'connection',
+          prompts: { database: 'memory' },
+          calledByTest: { prompts: { database: 'memory' } }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/connection-mongodb-mongoose.test',
-    specsChanges: [
-      {
-        generate: 'connection',
-        prompts: { database: 'mongodb', adapter: 'mongoose', connectionString: 'mongodb://localhost:27017/zz' },
-        calledByTest: {
-          prompts: { database: 'mongodb', adapter: 'mongoose', connectionString: 'mongodb://localhost:27017/zz' }
+    {
+      testName: 'a-specs/connection-mongodb-mongodb.test',
+      specsChanges: [
+        {
+          generate: 'connection',
+          prompts: { database: 'mongodb', adapter: 'mongodb', connectionString: 'mongodb://localhost:27017/zz' },
+          calledByTest: {
+            prompts: { database: 'mongodb', adapter: 'mongodb', connectionString: 'mongodb://localhost:27017/zz' },
+          }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/connection-mysql-sequelize.test',
-    specsChanges: [
-      {
-        generate: 'connection',
-        prompts: { database: 'mysql', adapter: 'sequelize', connectionString: 'mysql://root:@localhost:3306/zz' },
-        calledByTest: {
-          prompts: { database: 'mysql', adapter: 'sequelize', connectionString: 'mysql://root:@localhost:3306/zz' }
+    {
+      testName: 'a-specs/connection-mongodb-mongoose.test',
+      specsChanges: [
+        {
+          generate: 'connection',
+          prompts: { database: 'mongodb', adapter: 'mongoose', connectionString: 'mongodb://localhost:27017/zz' },
+          calledByTest: {
+            prompts: { database: 'mongodb', adapter: 'mongoose', connectionString: 'mongodb://localhost:27017/zz' },
+          }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/connection-mysql-knex.test',
-    specsChanges: [
-      {
-        generate: 'connection',
-        prompts: { database: 'mysql', adapter: 'knex', connectionString: 'mysql://root:@localhost:3306/zz' },
-        calledByTest: {
-          prompts: { database: 'mysql', adapter: 'knex', connectionString: 'mysql://root:@localhost:3306/zz' }
+    {
+      testName: 'a-specs/connection-mysql-sequelize.test',
+      specsChanges: [
+        {
+          generate: 'connection',
+          prompts: { database: 'mysql', adapter: 'sequelize', connectionString: 'mysql://root:@localhost:3306/zz' },
+          calledByTest: {
+            prompts: { database: 'mysql', adapter: 'sequelize', connectionString: 'mysql://root:@localhost:3306/zz' },
+          }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/connection-nedb.test',
-    specsChanges: [
-      {
-        generate: 'connection',
-        prompts: { database: 'nedb', connectionString: '../data' },
-        calledByTest: { prompts: { database: 'nedb', connectionString: '../data' } }
-      }
-    ],
-    compareOnlySpecs: true
-  },
-
-  {
-    testName: 'a-specs/connection-postgres-sequelize.test',
-    specsChanges: [
-      {
-        generate: 'connection',
-        prompts: { database: 'postgres', adapter: 'sequelize', connectionString: 'postgres://postgres:@localhost:5432/zz' },
-        calledByTest: {
-          prompts: { database: 'postgres', adapter: 'sequelize', connectionString: 'postgres://postgres:@localhost:5432/zz' }
+    {
+      testName: 'a-specs/connection-mysql-knex.test',
+      specsChanges: [
+        {
+          generate: 'connection',
+          prompts: { database: 'mysql', adapter: 'knex', connectionString: 'mysql://root:@localhost:3306/zz' },
+          calledByTest: {
+            prompts: { database: 'mysql', adapter: 'knex', connectionString: 'mysql://root:@localhost:3306/zz' },
+          }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/connection-postgres-knex.test',
-    specsChanges: [
-      {
-        generate: 'connection',
-        prompts: { database: 'postgres', adapter: 'knex', connectionString: 'postgres://postgres:@localhost:5432/zz' },
-        calledByTest: {
-          prompts: { database: 'postgres', adapter: 'knex', connectionString: 'postgres://postgres:@localhost:5432/zz' }
+    {
+      testName: 'a-specs/connection-nedb.test',
+      specsChanges: [
+        {
+          generate: 'connection',
+          prompts: { database: 'nedb', connectionString: '../data' },
+          calledByTest: { prompts: {database: 'nedb', connectionString: '../data'} }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/connection-rethinkdb.test',
-    specsChanges: [
-      {
-        generate: 'connection',
-        prompts: { database: 'rethinkdb', connectionString: 'rethinkdb://localhost:28015/zz' },
-        calledByTest: {
-          prompts: { database: 'rethinkdb', connectionString: 'rethinkdb://localhost:28015/zz' }
+    {
+      testName: 'a-specs/connection-postgres-sequelize.test',
+      specsChanges: [
+        {
+          generate: 'connection',
+          prompts: { database: 'postgres', adapter: 'sequelize', connectionString: 'postgres://postgres:@localhost:5432/zz' },
+          calledByTest: {
+            prompts: { database: 'postgres', adapter: 'sequelize', connectionString: 'postgres://postgres:@localhost:5432/zz' }
+          }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/connection-sqlite-sequelize.test',
-    specsChanges: [
-      {
-        generate: 'connection',
-        prompts: { database: 'sqlite', adapter: 'sequelize', connectionString: 'sqlite://zz.sqlite' },
-        calledByTest: {
-          prompts: { database: 'sqlite', adapter: 'sequelize', connectionString: 'sqlite://zz.sqlite' }
+    {
+      testName: 'a-specs/connection-postgres-knex.test',
+      specsChanges: [
+        {
+          generate: 'connection',
+          prompts: { database: 'postgres', adapter: 'knex', connectionString: 'postgres://postgres:@localhost:5432/zz' },
+          calledByTest: {
+            prompts: { database: 'postgres', adapter: 'knex', connectionString: 'postgres://postgres:@localhost:5432/zz' }
+          }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/connection-sqlite-knex.test',
-    specsChanges: [
-      {
-        generate: 'connection',
-        prompts: { database: 'sqlite', adapter: 'knex', connectionString: 'sqlite://zz.sqlite' },
-        calledByTest: {
-          prompts: { database: 'sqlite', adapter: 'knex', connectionString: 'sqlite://zz.sqlite' }
+    {
+      testName: 'a-specs/connection-rethinkdb.test',
+      specsChanges: [
+        {
+          generate: 'connection',
+          prompts: { database: 'rethinkdb', connectionString: 'rethinkdb://localhost:28015/zz' },
+          calledByTest: {
+            prompts: { database: 'rethinkdb', connectionString: 'rethinkdb://localhost:28015/zz' }
+          }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/connection-mssql-sequelize.test',
-    specsChanges: [
-      {
-        generate: 'connection',
-        prompts: { database: 'mssql', adapter: 'sequelize', connectionString: 'mssql://root:password@localhost:1433/zz' },
-        calledByTest: {
-          prompts: { database: 'mssql', adapter: 'sequelize', connectionString: 'mssql://root:password@localhost:1433/zz' }
+    {
+      testName: 'a-specs/connection-sqlite-sequelize.test',
+      specsChanges: [
+        {
+          generate: 'connection',
+          prompts: { database: 'sqlite', adapter: 'sequelize', connectionString: 'sqlite://zz.sqlite' },
+          calledByTest: {
+            prompts: { database: 'sqlite', adapter: 'sequelize', connectionString: 'sqlite://zz.sqlite' }
+          }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/connection-mssql-knex.test',
-    specsChanges: [
-      {
-        generate: 'connection',
-        prompts: { database: 'mssql', adapter: 'knex', connectionString: 'mssql://root:password@localhost:1433/zz' },
-        calledByTest: {
-          prompts: { database: 'mssql', adapter: 'knex', connectionString: 'mssql://root:password@localhost:1433/zz' }
+    {
+      testName: 'a-specs/connection-sqlite-knex.test',
+      specsChanges: [
+        {
+          generate: 'connection',
+          prompts: { database: 'sqlite', adapter: 'knex', connectionString: 'sqlite://zz.sqlite' },
+          calledByTest: {
+            prompts: { database: 'sqlite', adapter: 'knex', connectionString: 'sqlite://zz.sqlite' }
+          }
         }
-      }
-    ],
-    compareDirs: false,
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/service-generic.test',
-    specsChanges: [
-      {
-        generate: 'service',
-        prompts: {
-          adapter: 'generic',
+    {
+      testName: 'a-specs/connection-mssql-sequelize.test',
+      specsChanges: [
+        {
+          generate: 'connection',
+          prompts: { database: 'mssql', adapter: 'sequelize', connectionString: 'mssql://root:password@localhost:1433/zz' },
+          calledByTest: {
+            prompts: { database: 'mssql', adapter: 'sequelize', connectionString: 'mssql://root:password@localhost:1433/zz' }
+          }
+        }
+      ],
+      compareOnlySpecs: true
+    },
 
-          isAuthEntity: false,
-          name: 'users',
-          nameSingular: 'user',
-          subFolder: '',
-          path: '/users',
-          graphql: false
-        },
-        calledByTest: {
-          name: 'users',
+    {
+      testName: 'a-specs/connection-mssql-knex.test',
+      specsChanges: [
+        {
+          generate: 'connection',
+          prompts: { database: 'mssql', adapter: 'knex', connectionString: 'mssql://root:password@localhost:1433/zz' },
+          calledByTest: {
+            prompts: { database: 'mssql', adapter: 'knex', connectionString: 'mssql://root:password@localhost:1433/zz' }
+          }
+        }
+      ],
+      compareDirs: false,
+      compareOnlySpecs: true
+    },
+
+    {
+      testName: 'a-specs/service-generic.test',
+      specsChanges: [
+        {
+          generate: 'service',
           prompts: {
             adapter: 'generic',
 
-            isAuthEntity: false,
+            isAuthEntity: false, name: 'users', nameSingular: 'user',
+            subFolder: '', path: '/users', graphql: false,
+          },
+          calledByTest: {
             name: 'users',
-            nameSingular: 'user',
-            subFolder: '',
-            path: '/users',
-            graphql: false
+            prompts: {
+              adapter: 'generic',
+
+              isAuthEntity: false, name: 'users', nameSingular: 'user',
+              subFolder: '', path: '/users', graphql: false,
+            }
           }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/service-memory.test',
-    specsChanges: [
-      {
-        generate: 'service',
-        prompts: {
-          adapter: 'memory',
-
-          isAuthEntity: false,
-          name: 'users',
-          nameSingular: 'user',
-          subFolder: '',
-          path: '/users',
-          graphql: false
-        },
-        calledByTest: {
-          name: 'users',
+    {
+      testName: 'a-specs/service-memory.test',
+      specsChanges: [
+        {
+          generate: 'service',
           prompts: {
             adapter: 'memory',
 
-            isAuthEntity: false,
+            isAuthEntity: false, name: 'users', nameSingular: 'user',
+            subFolder: '', path: '/users', graphql: false,
+          },
+          calledByTest: {
             name: 'users',
-            nameSingular: 'user',
-            subFolder: '',
-            path: '/users',
-            graphql: false
+            prompts: {
+              adapter: 'memory',
+
+              isAuthEntity: false, name: 'users', nameSingular: 'user',
+              subFolder: '', path: '/users', graphql: false,
+            }
           }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/service-nedb.test',
-    specsChanges: [
-      {
-        generate: 'service',
-        prompts: {
-          adapter: 'nedb',
-
-          isAuthEntity: false,
-          name: 'users',
-          nameSingular: 'user',
-          subFolder: '',
-          path: '/users',
-          graphql: false,
-
-          database: 'nedb',
-          connectionString: '../data'
-        },
-        calledByTest: {
-          name: 'users',
+    {
+      testName: 'a-specs/service-nedb.test',
+      specsChanges: [
+        {
+          generate: 'service',
           prompts: {
             adapter: 'nedb',
 
-            isAuthEntity: false,
-            name: 'users',
-            nameSingular: 'user',
-            subFolder: '',
-            path: '/users',
-            graphql: false,
+            isAuthEntity: false, name: 'users', nameSingular: 'user',
+            subFolder: '', path: '/users', graphql: false,
 
-            database: 'nedb',
-            connectionString: '../data'
+            database: 'nedb', connectionString: '../data'
+          },
+          calledByTest: {
+            name: 'users',
+            prompts: {
+              adapter: 'nedb',
+
+              isAuthEntity: false, name: 'users', nameSingular: 'user',
+              subFolder: '', path: '/users', graphql: false,
+
+              database: 'nedb', connectionString: '../data'
+            }
           }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/service-mongodb.test',
-    specsChanges: [
-      {
-        generate: 'service',
-        prompts: {
-          adapter: 'mongodb',
-
-          isAuthEntity: false,
-          name: 'users',
-          nameSingular: 'user',
-          subFolder: '',
-          path: '/users',
-          graphql: false,
-
-          database: 'mongodb',
-          connectionString: 'mongodb://localhost:27017/zz'
-        },
-        calledByTest: {
-          name: 'users',
+    {
+      testName: 'a-specs/service-mongodb.test',
+      specsChanges: [
+        {
+          generate: 'service',
           prompts: {
             adapter: 'mongodb',
 
-            isAuthEntity: false,
-            name: 'users',
-            nameSingular: 'user',
-            subFolder: '',
-            path: '/users',
-            graphql: false,
+            isAuthEntity: false, name: 'users', nameSingular: 'user',
+            subFolder: '', path: '/users', graphql: false,
 
-            database: 'mongodb',
-            connectionString: 'mongodb://localhost:27017/zz'
+            database: 'mongodb', connectionString: 'mongodb://localhost:27017/zz'
+          },
+          calledByTest: {
+            name: 'users',
+            prompts: {
+              adapter: 'mongodb',
+
+              isAuthEntity: false, name: 'users', nameSingular: 'user',
+              subFolder: '', path: '/users', graphql: false,
+
+              database: 'mongodb', connectionString: 'mongodb://localhost:27017/zz'
+            }
           }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/service-mongoose.test',
-    specsChanges: [
-      {
-        generate: 'service',
-        prompts: {
-          adapter: 'mongoose',
-
-          isAuthEntity: false,
-          name: 'users',
-          nameSingular: 'user',
-          subFolder: '',
-          path: '/users',
-          graphql: false,
-
-          database: 'mongodb',
-          connectionString: 'mongodb://localhost:27017/zz'
-        },
-        calledByTest: {
-          name: 'users',
+    {
+      testName: 'a-specs/service-mongoose.test',
+      specsChanges: [
+        {
+          generate: 'service',
           prompts: {
             adapter: 'mongoose',
 
-            isAuthEntity: false,
-            name: 'users',
-            nameSingular: 'user',
-            subFolder: '',
-            path: '/users',
-            graphql: false,
+            isAuthEntity: false, name: 'users', nameSingular: 'user',
+            subFolder: '', path: '/users', graphql: false,
 
-            database: 'mongodb',
-            connectionString: 'mongodb://localhost:27017/zz'
+            database: 'mongodb', connectionString: 'mongodb://localhost:27017/zz'
+          },
+          calledByTest: {
+            name: 'users',
+            prompts: {
+              adapter: 'mongoose',
+
+              isAuthEntity: false, name: 'users', nameSingular: 'user',
+              subFolder: '', path: '/users', graphql: false,
+
+              database: 'mongodb', connectionString: 'mongodb://localhost:27017/zz'
+            }
           }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/service-sequelize-mysql.test',
-    specsChanges: [
-      {
-        generate: 'service',
-        prompts: {
-          adapter: 'sequelize',
-
-          isAuthEntity: false,
-          name: 'users',
-          nameSingular: 'user',
-          subFolder: '',
-          path: '/users',
-          graphql: false,
-
-          database: 'mysql',
-          connectionString: 'mysql://root:@localhost:3306/zz'
-        },
-        calledByTest: {
-          name: 'users',
+    {
+      testName: 'a-specs/service-sequelize-mysql.test',
+      specsChanges: [
+        {
+          generate: 'service',
           prompts: {
             adapter: 'sequelize',
 
-            isAuthEntity: false,
-            name: 'users',
-            nameSingular: 'user',
-            subFolder: '',
-            path: '/users',
-            graphql: false,
+            isAuthEntity: false, name: 'users', nameSingular: 'user',
+            subFolder: '', path: '/users', graphql: false,
 
-            database: 'mysql',
-            connectionString: 'mysql://root:@localhost:3306/zz'
+            database: 'mysql', connectionString: 'mysql://root:@localhost:3306/zz'
+          },
+          calledByTest: {
+            name: 'users',
+            prompts: {
+              adapter: 'sequelize',
+
+              isAuthEntity: false, name: 'users', nameSingular: 'user',
+              subFolder: '', path: '/users', graphql: false,
+
+              database: 'mysql', connectionString: 'mysql://root:@localhost:3306/zz'
+            }
           }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/service-sequelize-postgres.test',
-    specsChanges: [
-      {
-        generate: 'service',
-        prompts: {
-          adapter: 'sequelize',
-
-          isAuthEntity: false,
-          name: 'users',
-          nameSingular: 'user',
-          subFolder: '',
-          path: '/users',
-          graphql: false,
-
-          database: 'postgres',
-          connectionString: 'postgres://postgres:@localhost:5432/zz'
-        },
-        calledByTest: {
-          name: 'users',
+    {
+      testName: 'a-specs/service-sequelize-postgres.test',
+      specsChanges: [
+        {
+          generate: 'service',
           prompts: {
             adapter: 'sequelize',
 
-            isAuthEntity: false,
-            name: 'users',
-            nameSingular: 'user',
-            subFolder: '',
-            path: '/users',
-            graphql: false,
+            isAuthEntity: false, name: 'users', nameSingular: 'user',
+            subFolder: '', path: '/users', graphql: false,
 
-            database: 'postgres',
-            connectionString: 'postgres://postgres:@localhost:5432/zz'
+            database: 'postgres', connectionString: 'postgres://postgres:@localhost:5432/zz'
+          },
+          calledByTest: {
+            name: 'users',
+            prompts: {
+              adapter: 'sequelize',
+
+              isAuthEntity: false, name: 'users', nameSingular: 'user',
+              subFolder: '', path: '/users', graphql: false,
+
+              database: 'postgres', connectionString: 'postgres://postgres:@localhost:5432/zz'
+            }
           }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/service-sequelize-sqlite.test',
-    specsChanges: [
-      {
-        generate: 'service',
-        prompts: {
-          adapter: 'sequelize',
-
-          isAuthEntity: false,
-          name: 'users',
-          nameSingular: 'user',
-          subFolder: '',
-          path: '/users',
-          graphql: false,
-
-          database: 'sqlite',
-          connectionString: 'sqlite://zz.sqlite'
-        },
-        calledByTest: {
-          name: 'users',
+    {
+      testName: 'a-specs/service-sequelize-sqlite.test',
+      specsChanges: [
+        {
+          generate: 'service',
           prompts: {
             adapter: 'sequelize',
 
-            isAuthEntity: false,
-            name: 'users',
-            nameSingular: 'user',
-            subFolder: '',
-            path: '/users',
-            graphql: false,
+            isAuthEntity: false, name: 'users', nameSingular: 'user',
+            subFolder: '', path: '/users', graphql: false,
 
-            database: 'sqlite',
-            connectionString: 'sqlite://zz.sqlite'
+            database: 'sqlite', connectionString: 'sqlite://zz.sqlite'
+          },
+          calledByTest: {
+            name: 'users',
+            prompts: {
+              adapter: 'sequelize',
+
+              isAuthEntity: false, name: 'users', nameSingular: 'user',
+              subFolder: '', path: '/users', graphql: false,
+
+              database: 'sqlite', connectionString: 'sqlite://zz.sqlite'
+            }
           }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/service-knex-mysql.test',
-    specsChanges: [
-      {
-        generate: 'service',
-        prompts: {
-          adapter: 'knex',
-
-          isAuthEntity: false,
-          name: 'users',
-          nameSingular: 'user',
-          subFolder: '',
-          path: '/users',
-          graphql: false,
-
-          database: 'mysql',
-          connectionString: 'mysql://root:@localhost:3306/zz'
-        },
-        calledByTest: {
-          name: 'users',
+    {
+      testName: 'a-specs/service-knex-mysql.test',
+      specsChanges: [
+        {
+          generate: 'service',
           prompts: {
             adapter: 'knex',
 
-            isAuthEntity: false,
-            name: 'users',
-            nameSingular: 'user',
-            subFolder: '',
-            path: '/users',
-            graphql: false,
+            isAuthEntity: false, name: 'users', nameSingular: 'user',
+            subFolder: '', path: '/users', graphql: false,
 
-            database: 'mysql',
-            connectionString: 'mysql://root:@localhost:3306/zz'
+            database: 'mysql', connectionString: 'mysql://root:@localhost:3306/zz'
+          },
+          calledByTest: {
+            name: 'users',
+            prompts: {
+              adapter: 'knex',
+
+              isAuthEntity: false, name: 'users', nameSingular: 'user',
+              subFolder: '', path: '/users', graphql: false,
+
+              database: 'mysql', connectionString: 'mysql://root:@localhost:3306/zz'
+            }
           }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/service-knex-postgres.test',
-    specsChanges: [
-      {
-        generate: 'service',
-        prompts: {
-          adapter: 'knex',
-
-          isAuthEntity: false,
-          name: 'users',
-          nameSingular: 'user',
-          subFolder: '',
-          path: '/users',
-          graphql: false,
-
-          database: 'postgres',
-          connectionString: 'postgres://postgres:@localhost:5432/zz'
-        },
-        calledByTest: {
-          name: 'users',
+    {
+      testName: 'a-specs/service-knex-postgres.test',
+      specsChanges: [
+        {
+          generate: 'service',
           prompts: {
             adapter: 'knex',
 
-            isAuthEntity: false,
-            name: 'users',
-            nameSingular: 'user',
-            subFolder: '',
-            path: '/users',
-            graphql: false,
+            isAuthEntity: false, name: 'users', nameSingular: 'user',
+            subFolder: '', path: '/users', graphql: false,
 
-            database: 'postgres',
-            connectionString: 'postgres://postgres:@localhost:5432/zz'
+            database: 'postgres', connectionString: 'postgres://postgres:@localhost:5432/zz'
+          },
+          calledByTest: {
+            name: 'users',
+            prompts: {
+              adapter: 'knex',
+
+              isAuthEntity: false, name: 'users', nameSingular: 'user',
+              subFolder: '', path: '/users', graphql: false,
+
+              database: 'postgres', connectionString: 'postgres://postgres:@localhost:5432/zz'
+            }
           }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/service-knex-sqlite.test',
-    specsChanges: [
-      {
-        generate: 'service',
-        prompts: {
-          adapter: 'knex',
-
-          isAuthEntity: false,
-          name: 'users',
-          nameSingular: 'user',
-          subFolder: '',
-          path: '/users',
-          graphql: false,
-
-          database: 'sqlite',
-          connectionString: 'sqlite://zz.sqlite'
-        },
-        calledByTest: {
-          name: 'users',
+    {
+      testName: 'a-specs/service-knex-sqlite.test',
+      specsChanges: [
+        {
+          generate: 'service',
           prompts: {
             adapter: 'knex',
 
-            isAuthEntity: false,
-            name: 'users',
-            nameSingular: 'user',
-            subFolder: '',
-            path: '/users',
-            graphql: false,
+            isAuthEntity: false, name: 'users', nameSingular: 'user',
+            subFolder: '', path: '/users', graphql: false,
 
-            database: 'sqlite',
-            connectionString: 'sqlite://zz.sqlite'
+            database: 'sqlite', connectionString: 'sqlite://zz.sqlite'
+          },
+          calledByTest: {
+            name: 'users',
+            prompts: {
+              adapter: 'knex',
+
+              isAuthEntity: false, name: 'users', nameSingular: 'user',
+              subFolder: '', path: '/users', graphql: false,
+
+              database: 'sqlite', connectionString: 'sqlite://zz.sqlite'
+            }
           }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/service-knex-mssql.test',
-    specsChanges: [
-      {
-        generate: 'service',
-        prompts: {
-          adapter: 'knex',
-
-          isAuthEntity: false,
-          name: 'users',
-          nameSingular: 'user',
-          subFolder: '',
-          path: '/users',
-          graphql: false,
-
-          database: 'mssql',
-          connectionString: 'mssql://root:password@localhost:1433/zz'
-        },
-        calledByTest: {
-          name: 'users',
+    {
+      testName: 'a-specs/service-knex-mssql.test',
+      specsChanges: [
+        {
+          generate: 'service',
           prompts: {
             adapter: 'knex',
 
-            isAuthEntity: false,
-            name: 'users',
-            nameSingular: 'user',
-            subFolder: '',
-            path: '/users',
-            graphql: false,
+            isAuthEntity: false, name: 'users', nameSingular: 'user',
+            subFolder: '', path: '/users', graphql: false,
 
-            database: 'mssql',
-            connectionString: 'mssql://root:password@localhost:1433/zz'
+            database: 'mssql', connectionString: 'mssql://root:password@localhost:1433/zz'
+          },
+          calledByTest: {
+            name: 'users',
+            prompts: {
+              adapter: 'knex',
+
+              isAuthEntity: false, name: 'users', nameSingular: 'user',
+              subFolder: '', path: '/users', graphql: false,
+
+              database: 'mssql', connectionString: 'mssql://root:password@localhost:1433/zz'
+            }
           }
         }
-      }
-    ],
-    compareOnlySpecs: true
-  },
+      ],
+      compareOnlySpecs: true
+    },
 
-  {
-    testName: 'a-specs/service-sequelize-mssql.test',
-    specsChanges: [
-      {
-        generate: 'service',
-        prompts: {
-          adapter: 'sequelize',
-
-          isAuthEntity: false,
-          name: 'users',
-          nameSingular: 'user',
-          subFolder: '',
-          path: '/users',
-          graphql: false,
-
-          database: 'mssql',
-          connectionString: 'mssql://root:password@localhost:1433/zz'
-        },
-        calledByTest: {
-          name: 'users',
+    {
+      testName: 'a-specs/service-sequelize-mssql.test',
+      specsChanges: [
+        {
+          generate: 'service',
           prompts: {
             adapter: 'sequelize',
 
-            isAuthEntity: false,
-            name: 'users',
-            nameSingular: 'user',
-            subFolder: '',
-            path: '/users',
-            graphql: false,
+            isAuthEntity: false, name: 'users', nameSingular: 'user',
+            subFolder: '', path: '/users', graphql: false,
 
-            database: 'mssql',
-            connectionString: 'mssql://root:password@localhost:1433/zz'
+            database: 'mssql', connectionString: 'mssql://root:password@localhost:1433/zz'
+          },
+          calledByTest: {
+            name: 'users',
+            prompts: {
+              adapter: 'sequelize',
+
+              isAuthEntity: false, name: 'users', nameSingular: 'user',
+              subFolder: '', path: '/users', graphql: false,
+
+              database: 'mssql', connectionString: 'mssql://root:password@localhost:1433/zz'
+            }
           }
         }
-      }
-    ],
-    compareDirs: true, // make sure src/sequelize-mssql.js is generated
-    execute: false
-  },
+      ],
+      compareDirs: true, // make sure src/sequelize-mssql.js is generated
+      execute: false,
+    },
 
   // Test generating app using only generate commands (except for an initialization step)
   //
@@ -1055,59 +910,45 @@ const tests = [
   //
   // We therefore standardized on passing the prompts in specsChanges.calledByTest.prompts as well.
   // "Missing" prompt values can be set by the generator at the end of prompting().
-  {
-    testName: 'a-gens/js/cumulative.test',
-    specsChanges: [
-      {
-        generate: 'app',
-        prompts: {
-          name: 'z-1',
-          src: 'src1',
-          description: 'Project z-1',
-          packager: 'npm@>= 3.0.0',
-          providers: ['rest', 'socketio'],
-          environmentsAllowingSeedData: 'test',
-          seedData: false
-        },
-        calledByTest: {
+    { testName: 'a-gens/js/cumulative.test',
+      specsChanges: [
+        { generate: 'app',
           prompts: {
             name: 'z-1',
             src: 'src1',
             description: 'Project z-1',
             packager: 'npm@>= 3.0.0',
-            providers: ['rest', 'socketio'],
+            providers: [ 'rest', 'socketio' ],
             environmentsAllowingSeedData: 'test',
-            seedData: false
+            seedData: false,
+          },
+          calledByTest: {
+            prompts: {
+              name: 'z-1',
+              src: 'src1',
+              description: 'Project z-1',
+              packager: 'npm@>= 3.0.0',
+              providers: [ 'rest', 'socketio' ],
+              environmentsAllowingSeedData: 'test',
+              seedData: false,
+            }
           }
-        }
-      },
-      {
-        generate: 'connection',
-        prompts: {
-          adapter: 'nedb',
-          database: 'nedb',
-          connectionString: '../data'
         },
-        calledByTest: {
+        { generate: 'connection',
           prompts: {
             adapter: 'nedb',
             database: 'nedb',
             connectionString: '../data'
+          },
+          calledByTest: {
+            prompts: {
+              adapter: 'nedb',
+              database: 'nedb',
+              connectionString: '../data'
+            },
           }
-        }
-      },
-      {
-        generate: 'service',
-        prompts: {
-          name: 'users1',
-          nameSingular: 'users1',
-          subFolder: '',
-          adapter: 'nedb',
-          path: '/users-1',
-          graphql: false
         },
-        calledByTest: {
-          name: 'users1',
+        { generate: 'service',
           prompts: {
             name: 'users1',
             nameSingular: 'users1',
@@ -1115,36 +956,32 @@ const tests = [
             adapter: 'nedb',
             path: '/users-1',
             graphql: false
+          },
+          calledByTest: {
+            name: 'users1',
+            prompts: {
+              name: 'users1',
+              nameSingular: 'users1',
+              subFolder: '',
+              adapter: 'nedb',
+              path: '/users-1',
+              graphql: false
+            }
           }
-        }
-      },
-      {
-        generate: 'authentication',
-        prompts: {
-          strategies: ['local', 'auth0', 'google', 'facebook', 'github'],
-          entity: 'users1'
         },
-        calledByTest: {
+        { generate: 'authentication',
           prompts: {
-            strategies: ['local', 'auth0', 'google', 'facebook', 'github'],
+            strategies: [ 'local', 'auth0', 'google', 'facebook', 'github' ],
             entity: 'users1'
+          },
+          calledByTest: {
+            prompts: {
+              strategies: [ 'local', 'auth0', 'google', 'facebook', 'github' ],
+              entity: 'users1'
+            },
           }
-        }
-      },
-      {
-        generate: 'service',
-        prompts: {
-          isAuthEntity: false,
-          requiresAuth: true,
-          name: 'nedb1',
-          nameSingular: 'nedb1',
-          adapter: 'nedb',
-          subFolder: '',
-          path: '/nedb-1',
-          graphql: true
         },
-        calledByTest: {
-          name: 'nedb1',
+        { generate: 'service',
           prompts: {
             isAuthEntity: false,
             requiresAuth: true,
@@ -1154,80 +991,79 @@ const tests = [
             subFolder: '',
             path: '/nedb-1',
             graphql: true
+          },
+          calledByTest: {
+            name: 'nedb1',
+            prompts: {
+              isAuthEntity: false,
+              requiresAuth: true,
+              name: 'nedb1',
+              nameSingular: 'nedb1',
+              adapter: 'nedb',
+              subFolder: '',
+              path: '/nedb-1',
+              graphql: true
+            },
           }
-        }
-      },
-      {
-        generate: 'service',
-        prompts: {
-          isAuthEntity: false,
-          requiresAuth: false,
-          name: 'nedb2',
-          nameSingular: 'nedb2',
-          adapter: 'nedb',
-          subFolder: '',
-          path: '/nedb-2',
-          graphql: true
         },
-        calledByTest: {
-          name: 'nedb2',
+        { generate: 'service',
           prompts: {
             isAuthEntity: false,
-            requiresAuth: true,
-            name: 'nedb1',
-            nameSingular: 'nedb1',
+            requiresAuth: false,
+            name: 'nedb2',
+            nameSingular: 'nedb2',
             adapter: 'nedb',
             subFolder: '',
-            path: '/nedb-1',
+            path: '/nedb-2',
             graphql: true
+          },
+          calledByTest: {
+            name: 'nedb2',
+            prompts: {
+              isAuthEntity: false,
+              requiresAuth: true,
+              name: 'nedb1',
+              nameSingular: 'nedb1',
+              adapter: 'nedb',
+              subFolder: '',
+              path: '/nedb-1',
+              graphql: true
+            },
           }
-        }
-      },
-      {
-        generate: 'middleware',
-        prompts: {
-          name: 'mw1',
-          path: '*',
-          kebabName: 'mw-1',
-          camelName: 'mw1'
         },
-        calledByTest: {
+        { generate: 'middleware',
           prompts: {
             name: 'mw1',
             path: '*',
             kebabName: 'mw-1',
             camelName: 'mw1'
+          },
+          calledByTest: {
+            prompts: {
+              name: 'mw1',
+              path: '*',
+              kebabName: 'mw-1',
+              camelName: 'mw1'
+            },
           }
-        }
-      },
-      {
-        generate: 'middleware',
-        prompts: {
-          name: 'mw2',
-          path: 'mw2',
-          kebabName: 'mw-2',
-          camelName: 'mw2'
         },
-        calledByTest: {
+        { generate: 'middleware',
           prompts: {
             name: 'mw2',
             path: 'mw2',
             kebabName: 'mw-2',
             camelName: 'mw2'
+          },
+          calledByTest: {
+            prompts: {
+              name: 'mw2',
+              path: 'mw2',
+              kebabName: 'mw-2',
+              camelName: 'mw2'
+            },
           }
-        }
-      },
-      {
-        generate: 'graphql',
-        prompts: {
-          strategy: 'services',
-          path: '/graphql',
-          requiresAuth: false,
-          snakeName: 'graphql',
-          kebabName: 'graphql',
-          camelName: 'graphql'
         },
-        calledByTest: {
+        { generate: 'graphql',
           prompts: {
             strategy: 'services',
             path: '/graphql',
@@ -1235,19 +1071,28 @@ const tests = [
             snakeName: 'graphql',
             kebabName: 'graphql',
             camelName: 'graphql'
+          },
+          calledByTest: {
+            prompts: {
+              strategy: 'services',
+              path: '/graphql',
+              requiresAuth: false,
+              snakeName: 'graphql',
+              kebabName: 'graphql',
+              camelName: 'graphql'
+            },
           }
-        }
-      }
-      // since the services are not regenerated, no name.populate.js files are generated
-    ],
-    compareDirs: true,
-    execute: false
-  }
+        },
+        // since the services are not regenerated, no name.populate.js files are generated
+      ],
+      compareDirs: true,
+      execute: false,
+    },
 ];
 
 let appDir;
-const runFromTest = null; // 'cumulative-1-sequelize.test' //null;
-const runToTest = null; // 'cumulative-1-sequelize.test' //null;
+const runFromTest = null; //'cumulative-1-sequelize.test' //null;
+const runToTest = null; //'cumulative-1-sequelize.test' //null;
 const executeAll = false;
 
 let runTests = !runFromTest;
@@ -1259,32 +1104,32 @@ describe('generators-writing.test.js', function () {
     if (!runTests) return;
 
     describe(testName, function () {
-      it('writes code expected', async () => {
-        await Promise.resolve()
+      it('writes code expected', () => {
         return runFirstGeneration(testName, { skipInstall: true })
           .then(dir => {
+
             // There is no second generation step
             if (!specsChanges.length) {
-              return compareOnlySpecs
-                ? compareSpecs(appDir, `${testName}-expected`)
-                : compareCode(dir, `${testName}-expected`, compareDirs);
+              return compareOnlySpecs ?
+                compareSpecs(appDir, `${testName}-expected`) :
+                compareCode(dir, `${testName}-expected`, compareDirs);
             }
 
             // Generate on top of contents of working directory
             return runNextGenerator(dir, specsChanges, { skipInstall: true })
               .then(dir => {
-                return compareOnlySpecs
-                  ? compareSpecs(appDir, `${testName}-expected`)
-                  : compareCode(dir, `${testName}-expected`, compareDirs);
+                return compareOnlySpecs ?
+                  compareSpecs(appDir, `${testName}-expected`) :
+                  compareCode(dir, `${testName}-expected`, compareDirs);
               });
           });
       });
 
       if (executeAll || execute) {
-        it('runs test generated', async () => {
-          await Promise.resolve()
+        it('runs test generated', () => {
           return runFirstGeneration(testName, { skipInstall: false })
             .then(dir => {
+
               // There is no second generation step
               if (!specsChanges.length) {
                 return runExecute(dir);
@@ -1311,14 +1156,14 @@ describe('generators-writing.test.js', function () {
 });
 
 // Run the first generator
-function runFirstGeneration(testName, withOptions) {
-  // console.log('>runFirstGeneration', testName, withOptions);
+function runFirstGeneration (testName, withOptions) {
+  //console.log('>runFirstGeneration', testName, withOptions);
   return helpers.run(path.join(__dirname, '..', 'generators', 'all'))
     .inTmpDir(dir => {
       appDir = dir;
       // specs.app.name must be 'z-1' not 'z1' as Feathers-generate app converts the project name
       // to kebab-case during the prompt.
-      // console.log('288', path.join(__dirname, '..', 'test-expands', `${testName}-copy`), dir);
+      //console.log('288', path.join(__dirname, '..', 'test-expands', `${testName}-copy`), dir);
       fs.copySync(path.join(__dirname, '..', 'test-expands', `${testName}-copy`), dir);
 
       resetSpecs();
@@ -1333,7 +1178,7 @@ function runFirstGeneration(testName, withOptions) {
 // Run subsequent generators
 // Return working directory containing last generated app.
 function runNextGenerator(dir, specsChanges, withOptions, index = 1) {
-  // console.log('>runNextGenerator', dir);
+  //console.log('>runNextGenerator', dir);
   if (!specsChanges.length) return;
   const specsChg = specsChanges.shift();
 
@@ -1349,14 +1194,14 @@ function runNextGenerator(dir, specsChanges, withOptions, index = 1) {
         appDir = dirNext;
         console.log(`      ${index + 1} "generate ${specsChg.generate}" with ${JSON.stringify(specsChg.prompts).substr(0, 60)}`);
 
-        // console.log('314', dir, dirNext);
+        //console.log('314', dir, dirNext);
         fs.copySync(dir, dirNext);
 
         resetSpecs();
       })
       .withPrompts(Object.assign({},
         specsChg.prompts,
-        { action: 'force' } // force file overwrites
+        { action: 'force' }, // force file overwrites
       ))
       .withOptions(Object.assign({}, { calledByTest: specsChg.calledByTest || true }, withOptions))
       .then(dir => {
@@ -1377,17 +1222,17 @@ function runNextGenerator(dir, specsChanges, withOptions, index = 1) {
         appDir = dirNext;
         console.log(`      ${index + 1} change specs ${JSON.stringify(specsChg.merge).substr(0, 65)}`);
 
-        // console.log('314', dir, dirNext);
+        //console.log('314', dir, dirNext);
         fs.copySync(dir, dirNext);
 
-        // console.log('317', path.join(dir, 'feathers-gen-specs.json'));
+        //console.log('317', path.join(dir, 'feathers-gen-specs.json'));
         const prevJson = fs.readJsonSync(path.join(dir, 'feathers-gen-specs.json'));
         if (specsChg.before) {
           specsChg.before(prevJson);
         }
         nextJson = specsChg.merge ? merge(prevJson, specsChg.merge) : prevJson;
 
-        // console.log('322', path.join(dirNext, 'feathers-gen-specs.json'));
+        //console.log('322', path.join(dirNext, 'feathers-gen-specs.json'));
         fs.writeFileSync(path.join(dirNext, 'feathers-gen-specs.json'), JSON.stringify(nextJson, null, 2));
 
         resetSpecs();
@@ -1409,7 +1254,7 @@ function runNextGenerator(dir, specsChanges, withOptions, index = 1) {
 }
 
 // Run the 'test' script in package.json
-function runGeneratedTests(expectedText) {
+function runGeneratedTests (expectedText) {
   // console.log('>runGeneratedTests');
   return runCommand(packageInstaller, ['test'], { cwd: appDir })
     .then(({ buffer }) => {
@@ -1425,12 +1270,12 @@ function runGeneratedTests(expectedText) {
 
 // Start a process and wait either for it to exit
 // or to display a certain text
-function runCommand(cmd, args, options, text) {
+function runCommand (cmd, args, options, text) {
   console.log('..run shell command', cmd, args);
   return new Promise((resolve, reject) => {
     let buffer = '';
 
-    function addToBuffer(data) {
+    function addToBuffer (data) {
       buffer += data;
 
       if (text && buffer.indexOf(text) !== -1) {
@@ -1453,7 +1298,7 @@ function runCommand(cmd, args, options, text) {
   });
 }
 
-async function compareCode(appDir, testDir, compareDirs) {
+function compareCode (appDir, testDir, compareDirs) {
   // console.log('>compareCode', appDir, testDir, compareDirs);
   console.log('... comparing code');
   const appDirLen = appDir.length;
@@ -1466,9 +1311,9 @@ async function compareCode(appDir, testDir, compareDirs) {
     assert.deepEqual(actualPaths.relativePaths, expectedPaths.relativePaths, 'Unexpected files in generated dir');
   }
 
-  return Promise.all(actualPaths.paths.map(async actualPath => {
-    await compare(actualPath.path.substr(appDirLen), appDir, expectedDir);
-  }))
+  actualPaths.paths.forEach(actualPath => {
+    compare(actualPath.path.substr(appDirLen), appDir, expectedDir);
+  });
 
   /*
   const expectedDirLen = expectedDir.length;
@@ -1478,14 +1323,14 @@ async function compareCode(appDir, testDir, compareDirs) {
   */
 }
 
-function compareSpecs(appDir, testDir) {
+function compareSpecs (appDir, testDir) {
   console.log('... comparing feathers-gen-specs.json');
   const expectedDir = path.join(__dirname, '..', 'test-expands', testDir);
 
   compare(`${path.sep}feathers-gen-specs.json`, appDir, expectedDir);
 }
 
-function compare(fileName, appDir, expectedDir) {
+function compare (fileName, appDir, expectedDir) {
   // console.log('compare files', fileName);
   let expected;
 
@@ -1513,11 +1358,11 @@ function compare(fileName, appDir, expectedDir) {
     console.log(expected);
     console.log('^^^^^');
 
-    let str = diff.reduce(function (accum, part) {
+    let str = diff.reduce(function(accum, part) {
       // green for additions, red for deletions
       // grey for common parts
-      const color = part.added ? 'bgGreen'
-        : part.removed ? 'bgRed' : 'grey';
+      const color = part.added ? 'bgGreen' :
+        part.removed ? 'bgRed' : 'grey';
       const value = /(\r\n)|(\r)|(\n)/.test(part.value) ? '<EOL DIFF>' : part.value;
 
       return accum + value[color];
@@ -1532,7 +1377,7 @@ function compare(fileName, appDir, expectedDir) {
   }
 }
 
-function getFileNames(dir) {
+function getFileNames (dir) {
   // console.log('>getFileNames', dir);
   const nodes = klawSync(dir, { nodir: true })
     .filter(obj => obj.path.indexOf(`${path.sep}node_modules${path.sep}`) === -1 && obj.path.indexOf(`${path.sep}data${path.sep}`) === -1);


### PR DESCRIPTION
Reverts feathers-plus/generator-feathers-plus#151

- There seem to be large unexplained changes to the gnerated code, e.g.  examples/js/09-graphql/feathers-app/src/services/graphql/batchloader.resolvers.js . What is the reason for this?

- Tests fail locally on my machine after pulling PR#151. I don't see where the generator was changed in this PR to cause such changes.

```
  1) generators-writing.test.js
       graphql.test
         writes code expected:

      AssertionError [ERR_ASSERTION]: Unexpected contents for file /tmp/9acf36f91a28d6dcb0c91affded7270e38359018/src1/services/graphql/batchloader.resolvers.js
      + expected - actual

             },
       
             // findNedb1(query: JSON, params: JSON): [Nedb1!]
             findNedb1(parent, args, content, ast) {
      -        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
      +        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
               return nedb1.find(feathersParams).then(paginate(content)).then(extractAllItems);
             },
             // !end
       
--
             },
       
             // findNedb2(query: JSON, params: JSON): [Nedb2!]
             findNedb2(parent, args, content, ast) {
      -        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {   _id: 1 } } });
      +        const feathersParams = convertArgs(args, content, ast, { query: { $sort: {  _id: 1 } } });
               return nedb2.find(feathersParams).then(paginate(content)).then(extractAllItems);
             },
             // !end
             // !code: resolver_query_more // !end



```