### PR TITLE
Added insertion point to src/authentication.?s

### DIFF
--- a/generators/writing/templates/src/authentication.ejs
+++ b/generators/writing/templates/src/authentication.ejs
@@ -27,6 +27,7 @@
 
 <%- tplModuleExports(null, 'function (app) {', 'function (app: App) {') %>
   const config = app.get('authentication')<%- sc %>
+  <%- insertFragment('func_init') %>
 
   // Set up authentication with the secret
   app.configure(authentication(config))<%- sc %>

--- a/test-expands/a-gens/js/cumulative.test-expected/src1/authentication.js
+++ b/test-expands/a-gens/js/cumulative.test-expected/src1/authentication.js
@@ -14,6 +14,7 @@ const GithubStrategy = require('passport-github');
 
 let moduleExports = function (app) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/a-gens/js/test-authentication.test-expected/src1/authentication.js
+++ b/test-expands/a-gens/js/test-authentication.test-expected/src1/authentication.js
@@ -14,6 +14,7 @@ const GithubStrategy = require('passport-github');
 
 let moduleExports = function (app) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/a-gens/js/test-hook-integ.test-expected/src1/authentication.js
+++ b/test-expands/a-gens/js/test-hook-integ.test-expected/src1/authentication.js
@@ -14,6 +14,7 @@ const GithubStrategy = require('passport-github');
 
 let moduleExports = function (app) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/a-gens/js/test-hook-unit.test-expected/src1/authentication.js
+++ b/test-expands/a-gens/js/test-hook-unit.test-expected/src1/authentication.js
@@ -14,6 +14,7 @@ const GithubStrategy = require('passport-github');
 
 let moduleExports = function (app) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/a-gens/js/test-service.test-expected/src1/authentication.js
+++ b/test-expands/a-gens/js/test-service.test-expected/src1/authentication.js
@@ -14,6 +14,7 @@ const GithubStrategy = require('passport-github');
 
 let moduleExports = function (app) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/a-gens/ts/test-authentication.test-expected/src1/authentication.ts
+++ b/test-expands/a-gens/ts/test-authentication.test-expected/src1/authentication.ts
@@ -15,6 +15,7 @@ import { App } from './app.interface';
 
 let moduleExports = function (app: App) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/a-gens/ts/test-hook-integ.test-expected/src1/authentication.ts
+++ b/test-expands/a-gens/ts/test-hook-integ.test-expected/src1/authentication.ts
@@ -15,6 +15,7 @@ import { App } from './app.interface';
 
 let moduleExports = function (app: App) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/a-gens/ts/test-hook-unit.test-expected/src1/authentication.ts
+++ b/test-expands/a-gens/ts/test-hook-unit.test-expected/src1/authentication.ts
@@ -15,6 +15,7 @@ import { App } from './app.interface';
 
 let moduleExports = function (app: App) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/a-gens/ts/test-service.test-expected/src1/authentication.ts
+++ b/test-expands/a-gens/ts/test-service.test-expected/src1/authentication.ts
@@ -15,6 +15,7 @@ import { App } from './app.interface';
 
 let moduleExports = function (app: App) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/authentication-1.test-expected/src1/authentication.js
+++ b/test-expands/authentication-1.test-expected/src1/authentication.js
@@ -11,6 +11,7 @@ const Auth0Strategy = require('passport-auth0');
 
 let moduleExports = function (app) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/authentication-2.test-expected/src1/authentication.js
+++ b/test-expands/authentication-2.test-expected/src1/authentication.js
@@ -11,6 +11,7 @@ const Auth0Strategy = require('passport-auth0');
 
 let moduleExports = function (app) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/authentication-3.test-expected/src1/authentication.js
+++ b/test-expands/authentication-3.test-expected/src1/authentication.js
@@ -11,6 +11,7 @@ const Auth0Strategy = require('passport-auth0');
 
 let moduleExports = function (app) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/cumulative-1-generic.test-expected/src1/authentication.js
+++ b/test-expands/cumulative-1-generic.test-expected/src1/authentication.js
@@ -14,6 +14,7 @@ const GithubStrategy = require('passport-github');
 
 let moduleExports = function (app) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/cumulative-1-memory.test-expected/src1/authentication.js
+++ b/test-expands/cumulative-1-memory.test-expected/src1/authentication.js
@@ -14,6 +14,7 @@ const GithubStrategy = require('passport-github');
 
 let moduleExports = function (app) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/cumulative-1-mongo.test-expected/src1/authentication.js
+++ b/test-expands/cumulative-1-mongo.test-expected/src1/authentication.js
@@ -14,6 +14,7 @@ const GithubStrategy = require('passport-github');
 
 let moduleExports = function (app) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/cumulative-1-mongoose.test-expected/src1/authentication.js
+++ b/test-expands/cumulative-1-mongoose.test-expected/src1/authentication.js
@@ -14,6 +14,7 @@ const GithubStrategy = require('passport-github');
 
 let moduleExports = function (app) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/cumulative-1-nedb.test-expected/src1/authentication.js
+++ b/test-expands/cumulative-1-nedb.test-expected/src1/authentication.js
@@ -14,6 +14,7 @@ const GithubStrategy = require('passport-github');
 
 let moduleExports = function (app) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/cumulative-1-no-semicolons.test-expected/src1/authentication.js
+++ b/test-expands/cumulative-1-no-semicolons.test-expected/src1/authentication.js
@@ -14,6 +14,7 @@ const GithubStrategy = require('passport-github')
 
 let moduleExports = function (app) {
   const config = app.get('authentication')
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config))

--- a/test-expands/cumulative-2-hooks.test-expected/src1/authentication.js
+++ b/test-expands/cumulative-2-hooks.test-expected/src1/authentication.js
@@ -14,6 +14,7 @@ const GithubStrategy = require('passport-github');
 
 let moduleExports = function (app) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/cumulative-2-nedb-batchloaders.test-expected/src1/authentication.js
+++ b/test-expands/cumulative-2-nedb-batchloaders.test-expected/src1/authentication.js
@@ -14,6 +14,7 @@ const GithubStrategy = require('passport-github');
 
 let moduleExports = function (app) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/cumulative-2-sequelize-services.test-expected/src1/authentication.js
+++ b/test-expands/cumulative-2-sequelize-services.test-expected/src1/authentication.js
@@ -14,6 +14,7 @@ const GithubStrategy = require('passport-github');
 
 let moduleExports = function (app) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/graphql-auth.test-expected/src1/authentication.js
+++ b/test-expands/graphql-auth.test-expected/src1/authentication.js
@@ -11,6 +11,7 @@ const Auth0Strategy = require('passport-auth0');
 
 let moduleExports = function (app) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/regen-user-entity.test-expected/src1/authentication.js
+++ b/test-expands/regen-user-entity.test-expected/src1/authentication.js
@@ -14,6 +14,7 @@ const GithubStrategy = require('passport-github');
 
 let moduleExports = function (app) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/service-naming.test-expected/src1/authentication.js
+++ b/test-expands/service-naming.test-expected/src1/authentication.js
@@ -14,6 +14,7 @@ const GithubStrategy = require('passport-github');
 
 let moduleExports = function (app) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/ts-cumulative-1-generic.test-expected/src1/authentication.ts
+++ b/test-expands/ts-cumulative-1-generic.test-expected/src1/authentication.ts
@@ -15,6 +15,7 @@ import { App } from './app.interface';
 
 let moduleExports = function (app: App) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/ts-cumulative-1-memory.test-expected/src1/authentication.ts
+++ b/test-expands/ts-cumulative-1-memory.test-expected/src1/authentication.ts
@@ -15,6 +15,7 @@ import { App } from './app.interface';
 
 let moduleExports = function (app: App) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/ts-cumulative-1-mongo.test-expected/src1/authentication.ts
+++ b/test-expands/ts-cumulative-1-mongo.test-expected/src1/authentication.ts
@@ -15,6 +15,7 @@ import { App } from './app.interface';
 
 let moduleExports = function (app: App) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/ts-cumulative-1-mongoose.test-expected/src1/authentication.ts
+++ b/test-expands/ts-cumulative-1-mongoose.test-expected/src1/authentication.ts
@@ -15,6 +15,7 @@ import { App } from './app.interface';
 
 let moduleExports = function (app: App) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/ts-cumulative-1-nedb.test-expected/src1/authentication.ts
+++ b/test-expands/ts-cumulative-1-nedb.test-expected/src1/authentication.ts
@@ -15,6 +15,7 @@ import { App } from './app.interface';
 
 let moduleExports = function (app: App) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/ts-cumulative-2-hooks.test-expected/src1/authentication.ts
+++ b/test-expands/ts-cumulative-2-hooks.test-expected/src1/authentication.ts
@@ -15,6 +15,7 @@ import { App } from './app.interface';
 
 let moduleExports = function (app: App) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));

--- a/test-expands/ts-cumulative-2-sequelize-services.test-expected/src1/authentication.ts
+++ b/test-expands/ts-cumulative-2-sequelize-services.test-expected/src1/authentication.ts
@@ -15,6 +15,7 @@ import { App } from './app.interface';
 
 let moduleExports = function (app: App) {
   const config = app.get('authentication');
+  // !code: func_init // !end
 
   // Set up authentication with the secret
   app.configure(authentication(config));


### PR DESCRIPTION
(a) The following insertion point in src/authentication.?s is also an appropriate place to change the app configuration

// !<DEFAULT> code: init_config
app.set('generatorSpecs', generatorSpecs);
// !end

(b) Added the following insertion point to src/authentication.?s as it more explicitly addresses auth configuration:

let moduleExports = function (app: App) {
  const config = app.get('authentication');
  // !code: func_init // !end

(c) Changes manually made in package.json to authentication.strategies will still be lost on regeneration. Given the availability of options (a) and (b), I did not want to introduce, for the first time, code which scans package.json looking for manual changes to retain.

(d) Updated all the tests for the above.