### PR TITLE
updated roles->teams typo in docs/getstarted.md

### DIFF
--- a/docs/get-started/README.md
+++ b/docs/get-started/README.md
@@ -1120,7 +1120,7 @@ feathers-plus generate service
 ```
 
 <collapse-image title="Prompts 'generate service' for Roles with Model" url="/assets/get-started/generate-service-roles-model.png" />
-<collapse-image title="Prompts 'generate service' for Roles with Model" url="/assets/get-started/generate-service-teams-model.png" />
+<collapse-image title="Prompts 'generate service' for Teams with Model" url="/assets/get-started/generate-service-teams-model.png" />
 
 The Mongoose models now reflects the Feathers model:
 ```js


### PR DESCRIPTION
### Summary

Fixing a simple type in docs when regenerating Teams and Roles services.  Images show 'Roles' and 'Teams' regen, but heading labels them both as 'Roles'.

Since this is a fpg specific documentation I'm assuming it doesn't need a matching PR in feathers?


<img width="797" alt="image" src="https://user-images.githubusercontent.com/16613132/50645942-72335f80-0f3a-11e9-8b02-055efb2b388f.png">

