### PR TITLE
Generate requiredCustomResource text files.

### DIFF
--- a/lib/generator-fs.js
+++ b/lib/generator-fs.js
@@ -1,11 +1,13 @@
 
 const chalk = require('chalk');
 const makeDebug = require('debug');
+const os = require('os');
 const { join } = require('path');
 const doesFileExist = require('./does-file-exist');
 const { insertFragment } = require('./code-fragments');
 
 const debug = makeDebug('generator-feathers-plus:generator-fs');
+const EOL = os.EOL;
 const fileNames = [];
 
 module.exports = {
@@ -18,9 +20,9 @@ function generatorFs (generator, context1, todos) {
   const freeze = generator._specs.options.freeze || [];
   generator.conflicter.force = !generator._specs.options.inspectConflicts;
 
-  // type:   'tpl' - expand template, 'copy' - copy file, 'json' - write JSON as file.
+  // type:   'tpl' - expand template, 'copy' - copy file, 'json' - write JSON as file, 'write' - write string as file
   // src:    path & file of template or source file. Array of folder names or str.
-  // obj:    Object to write as JSON.
+  // obj:    Object to write as JSON, or string to write as string
   // dest:   path & file of destination. Array to .join() or str.
   // ifNew:  true: Write file only if it does not yet exist, false: always write it.
   // ifSkip: true: Do not write this file, false: write it.
@@ -67,6 +69,13 @@ function generatorFs (generator, context1, todos) {
           generator.fs.writeJSON(
             generator.destinationPath(destinationPath),
             obj
+          );
+          break;
+        case 'write':
+          debug('write', generator.destinationPath(destinationPath));
+          generator.fs.write(
+            generator.destinationPath(destinationPath),
+            obj.join(EOL)
           );
           break;
         default:


### PR DESCRIPTION
feathers-gen-specs.json
```json
{
  "options": {
    "ver": "1.0.0",
    "inspectConflicts": false,
    "semicolons": true,
    "freeze": [],
    "ts": false
  },
  "app": {
    "environmentsAllowingSeedData": "",
    "seedData": false,
    "name": "yy",
    "description": "Project yy",
    "src": "src",
    "packager": "npm@>= 3.0.0",
    "providers": [
      "rest",
      "socketio"
    ]
  },
  "services": {},
  "hooks": {},
  "requiredCustomResources": { // <---------------------------
    "files": {
      "text": [
        "src/custom-js.js"
      ]
    }
  }
}
```

feathers-gen-code.js
```js
// !module src/index.**

// !code: listening
console.log('listening');
// !end

// !module requiredCustomResources // <----------------------

// !code: src/custom-js.js
console.log('customJs.js line 1');

console.log('customJs.js line 2');
console.log('customJs.js line 3');
// !end
```

`generate all` creates src/custom-js.js if it does not already exist.

Published as f+/cli 0.7.77  ujsing generator v0.6.75 .

We'll later handle using requiredCustomResources.files.text to **replace/add** the following on `generate codelist`
```js
// !module requiredCustomResources

// !code: src/custom-js.js
console.log('customJs.js line 1');

console.log('customJs.js line 2');
console.log('customJs.js line 3');
// !end
```