### PR TITLE
(Initial) fix for 'DeprecationWarning: collection.ensureIndex is deprecated. Use createIndexes instead.'

### DIFF
--- a/generators/writing/templates/src/_adapters/mongodb.ejs
+++ b/generators/writing/templates/src/_adapters/mongodb.ejs
@@ -11,7 +11,7 @@
   let config = app.get('mongodb')<%- sc %>
   <%- insertFragment('func_init') %>
 
-  const promise = MongoClient.connect(config, { useNewUrlParser: true }).then(client => {
+  const promise = MongoClient.connect(config, { useNewUrlParser: true, useCreateIndex: true }).then(client => {
     // For mongodb <= 2.2
     if (client.collection) {
       return client<%- sc %>

--- a/generators/writing/templates/src/_adapters/mongoose.ejs
+++ b/generators/writing/templates/src/_adapters/mongoose.ejs
@@ -8,7 +8,7 @@
 
 <%- tplExport('function (app) {', 'function (app: App) {') %>
   mongoose.Promise = global.Promise<%- sc %>
-  mongoose.connect(app.get('mongodb'), { useNewUrlParser: true })
+  mongoose.connect(app.get('mongodb'), { useNewUrlParser: true, useCreateIndex: true })
     .then(({ connection }<%- tplTsOnly([': any']) -%>) => {
       // <%- lintDisableNextLineNoConsole %>
       console.log(`connected to "${connection.name}" database at ${connection.host}:${connection.port}`)<%- sc %>

--- a/test-expands/cumulative-1-mongo.test-expected/src1/mongodb.js
+++ b/test-expands/cumulative-1-mongo.test-expected/src1/mongodb.js
@@ -10,7 +10,7 @@ module.exports = function (app) {
   let config = app.get('mongodb');
   // !code: func_init // !end
 
-  const promise = MongoClient.connect(config, { useNewUrlParser: true }).then(client => {
+  const promise = MongoClient.connect(config, { useNewUrlParser: true, useCreateIndex: true }).then(client => {
     // For mongodb <= 2.2
     if (client.collection) {
       return client;

--- a/test-expands/cumulative-1-mongoose.test-expected/src1/mongoose.js
+++ b/test-expands/cumulative-1-mongoose.test-expected/src1/mongoose.js
@@ -7,7 +7,7 @@ const logger = require('./logger');
 
 module.exports = function (app) {
   mongoose.Promise = global.Promise;
-  mongoose.connect(app.get('mongodb'), { useNewUrlParser: true })
+  mongoose.connect(app.get('mongodb'), { useNewUrlParser: true, useCreateIndex: true })
     .then(({ connection }) => {
       // eslint-disable-next-line no-console
       console.log(`connected to "${connection.name}" database at ${connection.host}:${connection.port}`);

--- a/test-expands/regen-adapters-1.test-expected/src1/mongodb.js
+++ b/test-expands/regen-adapters-1.test-expected/src1/mongodb.js
@@ -10,7 +10,7 @@ module.exports = function (app) {
   let config = app.get('mongodb');
   // !code: func_init // !end
 
-  const promise = MongoClient.connect(config, { useNewUrlParser: true }).then(client => {
+  const promise = MongoClient.connect(config, { useNewUrlParser: true, useCreateIndex: true }).then(client => {
     // For mongodb <= 2.2
     if (client.collection) {
       return client;

--- a/test-expands/ts-cumulative-1-mongo.test-expected/src1/mongodb.ts
+++ b/test-expands/ts-cumulative-1-mongo.test-expected/src1/mongodb.ts
@@ -11,7 +11,7 @@ export default function (app: App) {
   let config = app.get('mongodb');
   // !code: func_init // !end
 
-  const promise = MongoClient.connect(config, { useNewUrlParser: true }).then(client => {
+  const promise = MongoClient.connect(config, { useNewUrlParser: true, useCreateIndex: true }).then(client => {
     // For mongodb <= 2.2
     if (client.collection) {
       return client;

--- a/test-expands/ts-cumulative-1-mongoose.test-expected/src1/mongoose.ts
+++ b/test-expands/ts-cumulative-1-mongoose.test-expected/src1/mongoose.ts
@@ -8,7 +8,7 @@ import logger from './logger';
 
 export default function (app: App) {
   mongoose.Promise = global.Promise;
-  mongoose.connect(app.get('mongodb'), { useNewUrlParser: true })
+  mongoose.connect(app.get('mongodb'), { useNewUrlParser: true, useCreateIndex: true })
     .then(({ connection }: any) => {
       // tslint:disable-next-line:no-console
       console.log(`connected to "${connection.name}" database at ${connection.host}:${connection.port}`);


### PR DESCRIPTION
### Summary

- [x] Tell us about the problem your pull request is solving.
node throws `DeprecationWarning: collection.ensureIndex is deprecated. Use createIndexes instead.` when you set a field to `unique` via uniqueItemProperties in *.schema.ts

Reproduce:
1. `feathers-plus generate app`
1. `feathers-plus generate service` of type mongoose call it `users`
1. update `users.schema.ts`, add a field `email` and make it unique by adding it to `uniqueItemProperties`
1. `feathers-plus generate all`
1. `npm run dev`
1. boek: node will throw `DeprecationWarning: collection.ensureIndex is deprecated. Use createIndexes instead.`

Fix:
Add `useNewUrlParser: true` to connection in `mongoose.ts`
```
// before
mongoose.connect(app.get('mongodb'), { useNewUrlParser: true })
// after
mongoose.connect(app.get('mongodb'), { useNewUrlParser: true, useCreateIndex: true })
```

At https://mongoosejs.com/docs/deprecations.html#-ensureindex- ensureIndex is deprecated and we should add `useCreateIndex: true` to the connection. According their docs "There are no intentional backwards breaking changes with the useCreateIndex option, so you should be able to turn this option on without any code changes"

- [x] Are there any open issues that are related to this?
No, I went straight for PR, let me know if this is better as issue first with related PR

- [x] Is this PR dependent on PRs in other repos?
No

### Other Information

I have updated the two .ejs generators, plus the expected test outputs and `npm test` returns 73 passing.

I haven't updated all the example code in /examples - let me know if I should do this too

Cheers