### PR TITLE
feat: add favicon related insertion points

### DIFF
--- a/examples/js/02-app/feathers-app/src/app.js
+++ b/examples/js/02-app/feathers-app/src/app.js
@@ -1,11 +1,14 @@
 
 // Configure Feathers app. (Can be re-generated.)
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -36,7 +39,10 @@ app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // Host the public folder
 app.use('/', express.static(app.get('public')));
 // !code: use_end // !end

--- a/examples/js/03-authentication/feathers-app/src/app.js
+++ b/examples/js/03-authentication/feathers-app/src/app.js
@@ -1,11 +1,14 @@
 
 // Configure Feathers app. (Can be re-generated.)
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -38,7 +41,10 @@ app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // Host the public folder
 app.use('/', express.static(app.get('public')));
 // !code: use_end // !end

--- a/examples/js/04-model/feathers-app/src/app.js
+++ b/examples/js/04-model/feathers-app/src/app.js
@@ -1,11 +1,14 @@
 
 // Configure Feathers app. (Can be re-generated.)
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -38,7 +41,10 @@ app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // Host the public folder
 app.use('/', express.static(app.get('public')));
 // !code: use_end // !end

--- a/examples/js/05-secret/feathers-app/src/app.js
+++ b/examples/js/05-secret/feathers-app/src/app.js
@@ -1,11 +1,14 @@
 
 // Configure Feathers app. (Can be re-generated.)
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -38,7 +41,10 @@ app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // Host the public folder
 app.use('/', express.static(app.get('public')));
 // !code: use_end // !end

--- a/examples/js/06-service/feathers-app/src/app.js
+++ b/examples/js/06-service/feathers-app/src/app.js
@@ -1,11 +1,14 @@
 
 // Configure Feathers app. (Can be re-generated.)
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -38,7 +41,10 @@ app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // Host the public folder
 app.use('/', express.static(app.get('public')));
 // !code: use_end // !end

--- a/examples/js/07-fakes/feathers-app/src/app.js
+++ b/examples/js/07-fakes/feathers-app/src/app.js
@@ -1,11 +1,14 @@
 
 // Configure Feathers app. (Can be re-generated.)
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -38,7 +41,10 @@ app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // Host the public folder
 app.use('/', express.static(app.get('public')));
 // !code: use_end // !end

--- a/examples/js/09-graphql/feathers-app/src/app.js
+++ b/examples/js/09-graphql/feathers-app/src/app.js
@@ -1,11 +1,14 @@
 
 // Configure Feathers app. (Can be re-generated.)
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -38,7 +41,10 @@ app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // Host the public folder
 app.use('/', express.static(app.get('public')));
 // !code: use_end // !end

--- a/examples/js/10-hook/feathers-app/src/app.js
+++ b/examples/js/10-hook/feathers-app/src/app.js
@@ -1,11 +1,14 @@
 
 // Configure Feathers app. (Can be re-generated.)
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -38,7 +41,10 @@ app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // Host the public folder
 app.use('/', express.static(app.get('public')));
 // !code: use_end // !end

--- a/examples/js/11-test/feathers-app/src/app.js
+++ b/examples/js/11-test/feathers-app/src/app.js
@@ -1,11 +1,14 @@
 
 // Configure Feathers app. (Can be re-generated.)
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -38,7 +41,10 @@ app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // Host the public folder
 app.use('/', express.static(app.get('public')));
 // !code: use_end // !end

--- a/examples/js/12-test-examples/feathers-app/src/app.js
+++ b/examples/js/12-test-examples/feathers-app/src/app.js
@@ -1,11 +1,14 @@
 
 // Configure Feathers app. (Can be re-generated.)
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -37,7 +40,10 @@ app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // Host the public folder
 app.use('/', express.static(app.get('public')));
 // !code: use_end // !end

--- a/examples/ts/02-app/feathers-app/src/app.ts
+++ b/examples/ts/02-app/feathers-app/src/app.ts
@@ -1,11 +1,14 @@
 
 // Configure Feathers app. (Can be re-generated.)
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -37,7 +40,10 @@ app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // Host the public folder
 app.use('/', express.static(app.get('public')));
 // !code: use_end // !end

--- a/examples/ts/03-authentication/feathers-app/src/app.ts
+++ b/examples/ts/03-authentication/feathers-app/src/app.ts
@@ -1,11 +1,14 @@
 
 // Configure Feathers app. (Can be re-generated.)
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -39,7 +42,10 @@ app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // Host the public folder
 app.use('/', express.static(app.get('public')));
 // !code: use_end // !end

--- a/examples/ts/04-model/feathers-app/src/app.ts
+++ b/examples/ts/04-model/feathers-app/src/app.ts
@@ -1,11 +1,14 @@
 
 // Configure Feathers app. (Can be re-generated.)
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -39,7 +42,10 @@ app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // Host the public folder
 app.use('/', express.static(app.get('public')));
 // !code: use_end // !end

--- a/examples/ts/05-secret/feathers-app/src/app.ts
+++ b/examples/ts/05-secret/feathers-app/src/app.ts
@@ -1,11 +1,14 @@
 
 // Configure Feathers app. (Can be re-generated.)
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -39,7 +42,10 @@ app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // Host the public folder
 app.use('/', express.static(app.get('public')));
 // !code: use_end // !end

--- a/examples/ts/06-service/feathers-app/src/app.ts
+++ b/examples/ts/06-service/feathers-app/src/app.ts
@@ -1,11 +1,14 @@
 
 // Configure Feathers app. (Can be re-generated.)
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -39,7 +42,10 @@ app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // Host the public folder
 app.use('/', express.static(app.get('public')));
 // !code: use_end // !end

--- a/examples/ts/07-fakes/feathers-app/src/app.ts
+++ b/examples/ts/07-fakes/feathers-app/src/app.ts
@@ -1,11 +1,14 @@
 
 // Configure Feathers app. (Can be re-generated.)
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -39,7 +42,10 @@ app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // Host the public folder
 app.use('/', express.static(app.get('public')));
 // !code: use_end // !end

--- a/examples/ts/09-graphql/feathers-app/src/app.ts
+++ b/examples/ts/09-graphql/feathers-app/src/app.ts
@@ -1,11 +1,14 @@
 
 // Configure Feathers app. (Can be re-generated.)
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -39,7 +42,10 @@ app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // Host the public folder
 app.use('/', express.static(app.get('public')));
 // !code: use_end // !end

--- a/examples/ts/10-hook/feathers-app/src/app.ts
+++ b/examples/ts/10-hook/feathers-app/src/app.ts
@@ -1,11 +1,14 @@
 
 // Configure Feathers app. (Can be re-generated.)
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -39,7 +42,10 @@ app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // Host the public folder
 app.use('/', express.static(app.get('public')));
 // !code: use_end // !end

--- a/examples/ts/11-test/feathers-app/src/app.ts
+++ b/examples/ts/11-test/feathers-app/src/app.ts
@@ -1,11 +1,14 @@
 
 // Configure Feathers app. (Can be re-generated.)
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -39,7 +42,10 @@ app.use(cors());
 app.use(compress());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // Host the public folder
 app.use('/', express.static(app.get('public')));
 // !code: use_end // !end

--- a/generators/writing/templates/src/app.ejs
+++ b/generators/writing/templates/src/app.ejs
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 <%- insertFragment('preface') %>
 <%- tplImports('path', null, 'as') %>
-<%- tplImports('favicon', 'serve-favicon', 'req') %>
 <%- tplImports('compress', 'compression', 'req') %>
 <%- tplImports('cors', null, 'req') %>
 <%- tplImports('helmet', null, 'req') %>
 <%- tplImports('logger', './logger') %>
+
+<%- insertFragment('favicon_import', [
+  `${tplImports('favicon', 'serve-favicon', 'req')}`
+]) %>
 
 <%- tplImports('feathers', '@feathersjs/feathers') %>
 <%# -%>
@@ -72,7 +75,10 @@ app.use(express.urlencoded(
     '  { extended: true }'
   ]) %>
 ))<%- sc %>
-app.use(favicon(path.join(app.get('public'), 'favicon.ico')))<%- sc %>
+<%- insertFragment('use_favicon', [
+  '// Use favicon',
+  `app.use(favicon(path.join(app.get('public'), 'favicon.ico')))${sc}`
+]) %>
 <%- insertFragment('use_static', [
   '// Host the public folder',
   `app.use('/', express.static(app.get('public')))${sc}`

--- a/test-expands/a-gens/js/cumulative.test-expected/src1/app.js
+++ b/test-expands/a-gens/js/cumulative.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/a-gens/js/test-authentication.test-expected/src1/app.js
+++ b/test-expands/a-gens/js/test-authentication.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/a-gens/js/test-hook-integ.test-expected/src1/app.js
+++ b/test-expands/a-gens/js/test-hook-integ.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/a-gens/js/test-hook-unit.test-expected/src1/app.js
+++ b/test-expands/a-gens/js/test-hook-unit.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/a-gens/js/test-service.test-expected/src1/app.js
+++ b/test-expands/a-gens/js/test-service.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/a-gens/ts/test-authentication.test-expected/src1/app.ts
+++ b/test-expands/a-gens/ts/test-authentication.test-expected/src1/app.ts
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -51,7 +54,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/a-gens/ts/test-hook-integ.test-expected/src1/app.ts
+++ b/test-expands/a-gens/ts/test-hook-integ.test-expected/src1/app.ts
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -51,7 +54,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/a-gens/ts/test-hook-unit.test-expected/src1/app.ts
+++ b/test-expands/a-gens/ts/test-hook-unit.test-expected/src1/app.ts
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -51,7 +54,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/a-gens/ts/test-service.test-expected/src1/app.ts
+++ b/test-expands/a-gens/ts/test-service.test-expected/src1/app.ts
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -51,7 +54,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/a-specs/service-sequelize-mssql.test-expected/src1/app.js
+++ b/test-expands/a-specs/service-sequelize-mssql.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/app-code-blocks.test-expected/src1/app.js
+++ b/test-expands/app-code-blocks.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -49,7 +52,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/app-eslintrc.test-expected/src1/app.js
+++ b/test-expands/app-eslintrc.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -49,7 +52,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/app.test-expected/src1/app.js
+++ b/test-expands/app.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -49,7 +52,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/authentication-1.test-expected/src1/app.js
+++ b/test-expands/authentication-1.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/authentication-2.test-expected/src1/app.js
+++ b/test-expands/authentication-2.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/authentication-3.test-expected/src1/app.js
+++ b/test-expands/authentication-3.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/cumulative-1-generic.test-expected/src1/app.js
+++ b/test-expands/cumulative-1-generic.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/cumulative-1-memory.test-expected/src1/app.js
+++ b/test-expands/cumulative-1-memory.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/cumulative-1-mongo.test-expected/src1/app.js
+++ b/test-expands/cumulative-1-mongo.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -51,7 +54,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/cumulative-1-mongoose.test-expected/src1/app.js
+++ b/test-expands/cumulative-1-mongoose.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -51,7 +54,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/cumulative-1-nedb.test-expected/src1/app.js
+++ b/test-expands/cumulative-1-nedb.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/cumulative-1-no-semicolons.test-expected/src1/app.js
+++ b/test-expands/cumulative-1-no-semicolons.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path')
-const favicon = require('serve-favicon')
 const compress = require('compression')
 const cors = require('cors')
 const helmet = require('helmet')
 const logger = require('./logger')
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon')
+// !end
 
 const feathers = require('@feathersjs/feathers')
 const configuration = require('@feathersjs/configuration')
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ))
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')))
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')))

--- a/test-expands/cumulative-2-hooks.test-expected/src1/app.js
+++ b/test-expands/cumulative-2-hooks.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/cumulative-2-nedb-batchloaders.test-expected/src1/app.js
+++ b/test-expands/cumulative-2-nedb-batchloaders.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/cumulative-2-sequelize-services.test-expected/src1/app.js
+++ b/test-expands/cumulative-2-sequelize-services.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -51,7 +54,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/graphql-auth.test-expected/src1/app.js
+++ b/test-expands/graphql-auth.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/graphql.test-expected/src1/app.js
+++ b/test-expands/graphql.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -49,7 +52,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/middleware.test-expected/src1/app.js
+++ b/test-expands/middleware.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -49,7 +52,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/name-space.test-expected/src1/app.js
+++ b/test-expands/name-space.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -49,7 +52,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/regen-adapters-1.test-expected/src1/app.js
+++ b/test-expands/regen-adapters-1.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/regen-user-entity.test-expected/src1/app.js
+++ b/test-expands/regen-user-entity.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/scaffolding.test-expected/src1/app.js
+++ b/test-expands/scaffolding.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -49,7 +52,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/service-naming.test-expected/src1/app.js
+++ b/test-expands/service-naming.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/service.test-expected/src1/app.js
+++ b/test-expands/service.test-expected/src1/app.js
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 const path = require('path');
-const favicon = require('serve-favicon');
 const compress = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
 const logger = require('./logger');
+
+// !<DEFAULT> code: favicon_import
+const favicon = require('serve-favicon');
+// !end
 
 const feathers = require('@feathersjs/feathers');
 const configuration = require('@feathersjs/configuration');
@@ -49,7 +52,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/ts-cumulative-1-generic.test-expected/src1/app.ts
+++ b/test-expands/ts-cumulative-1-generic.test-expected/src1/app.ts
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -51,7 +54,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/ts-cumulative-1-memory.test-expected/src1/app.ts
+++ b/test-expands/ts-cumulative-1-memory.test-expected/src1/app.ts
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -51,7 +54,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/ts-cumulative-1-mongo.test-expected/src1/app.ts
+++ b/test-expands/ts-cumulative-1-mongo.test-expected/src1/app.ts
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -52,7 +55,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/ts-cumulative-1-mongoose.test-expected/src1/app.ts
+++ b/test-expands/ts-cumulative-1-mongoose.test-expected/src1/app.ts
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -52,7 +55,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/ts-cumulative-1-nedb.test-expected/src1/app.ts
+++ b/test-expands/ts-cumulative-1-nedb.test-expected/src1/app.ts
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -51,7 +54,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/ts-cumulative-2-hooks.test-expected/src1/app.ts
+++ b/test-expands/ts-cumulative-2-hooks.test-expected/src1/app.ts
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -51,7 +54,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/ts-cumulative-2-sequelize-services.test-expected/src1/app.ts
+++ b/test-expands/ts-cumulative-2-sequelize-services.test-expected/src1/app.ts
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -52,7 +55,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));

--- a/test-expands/ts-name-space.test-expected/src1/app.ts
+++ b/test-expands/ts-name-space.test-expected/src1/app.ts
@@ -2,11 +2,14 @@
 // Configure Feathers app. (Can be re-generated.)
 // !code: preface // !end
 import * as path from 'path';
-import favicon from 'serve-favicon';
 import compress from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import logger from './logger';
+
+// !<DEFAULT> code: favicon_import
+import favicon from 'serve-favicon';
+// !end
 
 import feathers from '@feathersjs/feathers';
 import configuration from '@feathersjs/configuration';
@@ -50,7 +53,10 @@ app.use(express.urlencoded(
   { extended: true }
   // !end
 ));
+// !<DEFAULT> code: use_favicon
+// Use favicon
 app.use(favicon(path.join(app.get('public'), 'favicon.ico')));
+// !end
 // !<DEFAULT> code: use_static
 // Host the public folder
 app.use('/', express.static(app.get('public')));


### PR DESCRIPTION
### Summary

Since `static` content has its own insertion point, it may be useful to be able to have the same for favicon. Doing so allows us to remove favicon behavior when not needed, the same way we do for static content. Example:  building a REST api without any static asset or html.

Two insert points were created in `app.ejs`:
 - `favicon_import` for import of `serve-favicon`
 - `use_favicon` for the the `app.use` statement