### PR TITLE
fix: remove @types/winston from generated devDependencies

### DIFF
--- a/generators/writing/index.js
+++ b/generators/writing/index.js
@@ -540,7 +540,6 @@ module.exports = function generatorWriting (generator, what) {
         '@types/lodash.merge',
         '@types/mocha',
         '@types/request-promise',
-        '@types/winston',
         'ts-mocha',
         'ts-node',
         'tslint',

--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "@types/passport-github": "^1.1.3",
     "@types/request-promise": "^4.1.42",
     "@types/serve-favicon": "^2.2.30",
-    "@types/winston": "^2.4.4",
     "ajv": "5.5.2",
     "body-parser": "^1.18.3",
     "compression": "^1.7.3",


### PR DESCRIPTION
### Summary

As stated in #196, `@types/winston` is a deprecated stub typing (see deprecation notice on https://www.npmjs.com/package/@types/winston). 

Typing is included in core `winston` package. We can then remove it from the generator.

--- 

Closes: #196