### PR TITLE
fix: typescript array typing form schema array

### DIFF
--- a/lib/service-specs-to-typescript.js
+++ b/lib/service-specs-to-typescript.js
@@ -12,13 +12,25 @@ module.exports = function serviceSpecsToTypescript (specsService, feathersSpec, 
     ID: idType,
     integer: 'number',
   };
+  const primitiveArrayTypes = ['string', 'number', 'boolean'];
 
   Object.keys(properties).forEach(name => {
     const property = properties[name];
     if (name !== idName && (name === 'id' || name === '_id')) return;
 
-    let subTypes, subTypesStr;
+    let subTypes, subTypesStr, arrayElementType;
     switch (property.type) {
+      case 'array':
+        if (primitiveArrayTypes.includes(property.items.type)) {
+          arrayElementType = property.items.type;
+        } else {
+          arrayElementType = (property.items.type === 'ID' || property.items.type === idName)
+            ? idType
+            : 'any';
+        }
+
+        typescriptTypes.push(`${name}: ${arrayElementType}[]`);
+        break;
       case 'object':
         subTypes = serviceSpecsToTypescript(specsService, property, feathersExtension, ++depth);
         subTypesStr = subTypes.typescriptTypes.map(str => `  ${str}`).join(`;${EOL}`);

--- a/lib/service-specs-to-typescript.js
+++ b/lib/service-specs-to-typescript.js
@@ -21,12 +21,13 @@ module.exports = function serviceSpecsToTypescript (specsService, feathersSpec, 
     let subTypes, subTypesStr, arrayElementType;
     switch (property.type) {
       case 'array':
-        if (primitiveArrayTypes.includes(property.items.type)) {
-          arrayElementType = property.items.type;
-        } else {
-          arrayElementType = (property.items.type === 'ID' || property.items.type === idName)
-            ? idType
-            : 'any';
+        const itemsType = property.items.type || undefined ;
+        arrayElementType = 'any';
+
+        if (primitiveArrayTypes.includes(itemsType)) {
+          arrayElementType = itemsType;
+        } else if ((itemsType === 'ID' || itemsType === idName) && primitiveArrayTypes.includes(idType)) {
+          arrayElementType = idType;
         }
 
         typescriptTypes.push(`${name}: ${arrayElementType}[]`);

--- a/test/json-schema/marshall-app.test.js
+++ b/test/json-schema/marshall-app.test.js
@@ -1514,8 +1514,8 @@ const expectedTypescriptTypes = {
   ],
   businesses: [
     "name: string",
-    "phones: array",
-    "emails: array",
+    "phones: any[]",
+    "emails: any[]",
     "primaryContact: string",
     "notes: string"
   ],
@@ -1524,7 +1524,7 @@ const expectedTypescriptTypes = {
     "path: string",
     "sortOrder: number",
     "clientId: unknown",
-    "environmentIds: array",
+    "environmentIds: string[]",
     "isGlobal: boolean"
   ],
   clients: [
@@ -1568,7 +1568,7 @@ const expectedTypescriptTypes = {
     "content: string",
     "mediaUrl: string",
     "uploadInfo: string",
-    "location: {\n  type: string;\n  coordinates: array\n}"
+    "location: {\n  type: string;\n  coordinates: string[]\n}"
   ],
   infoboxTypes: [
     "name: string",
@@ -1589,8 +1589,8 @@ const expectedTypescriptTypes = {
     "primaryPhotoUrl: string",
     "primaryPhotoCoordinates: string",
     "primaryPhotoUploadInfo: string",
-    "categories: array",
-    "location: {\n  type: string;\n  coordinates: array\n}",
+    "categories: any[]",
+    "location: {\n  type: string;\n  coordinates: string[]\n}",
     "phone: string",
     "tourLink: string",
     "learnMoreLink: string",
@@ -1607,16 +1607,16 @@ const expectedTypescriptTypes = {
     "linkMeta: {\n  url: string;\n  target: string\n}",
     "percentX: number",
     "percentY: number",
-    "coordinates: array"
+    "coordinates: number[]"
   ],
   panos: [
     "name: string",
     "slug: string",
     "imageUrl: string",
     "uploadInfo: {\n\n}",
-    "location: {\n  type: string;\n  coordinates: array\n}",
-    "tags: array",
-    "tagIds: array"
+    "location: {\n  type: string;\n  coordinates: any[]\n}",
+    "tags: string[]",
+    "tagIds: string[]"
   ],
   salesLeads: [
     "name: string",


### PR DESCRIPTION
### Summary

As discussed in #195 when `array` type is defined in schema, it produces an invalid Typescript `array` type instead of standard TS one such as `any[], string[], boolean[], number[]`.

The fix may be a naive approach that could for sure be improved. Basically it checks:
 - if the type within 'items.type' is primitive, just add it to `[]` to compose primitive array typing
 - if the type is `ID` or corresponds to `idName`, then we retrieve `idType`.
 - For everything else (for example objects) we use `any[]`

---

ping @NickBolles 