### PR TITLE
Remove duplicate imports fragment

### DIFF
--- a/generators/writing/templates/src/services/_service/name.service-mongodb.ejs
+++ b/generators/writing/templates/src/services/_service/name.service-mongodb.ejs
@@ -7,7 +7,6 @@
 <%- insertFragment('imports', [
   `// ${tplImports('$jsonSchema', `./${kebabName}.mongo`, 'req', 'let')}`
 ]) %>
-<%- insertFragment('imports') %>
 <%- insertFragment('init') %>
 
 <%- tplModuleExports(null, 'function (app) {', 'function (app: App) {') %>


### PR DESCRIPTION
This removes the duplicate `imports` fragment from the top of the mongodb service file:

```js
// Initializes the `transactions` service on path `/transactions`
const createService = require('feathers-mongodb')
const hooks = require('./transactions.hooks')
// !<DEFAULT> code: imports
// let $jsonSchema = require('./transactions.mongo')
// !end
// !code: imports // !end
// !code: init // !end

```