### PR TITLE
sequelize mssql adapter fix

### DIFF
--- a/generators/writing/templates/src/_adapters/sequelize-mssql.ejs
+++ b/generators/writing/templates/src/_adapters/sequelize-mssql.ejs
@@ -47,7 +47,7 @@ const operatorsAliases = {
 <%- tplExport('function (app) {', 'function (app: App) {') %>
   let connectionString = app.get('mssql')<%- sc %>
   let connection = url.parse(connectionString)<%- sc %>
-  let database = connection.path<%- tplTsOnly(['!']) %>.substring(1, connection.path.length)<%- sc %>
+  let database = connection.path<%- tplTsOnly(['!']) %>.substring(1, connection.path<%- tplTsOnly(['!']) %>.length)<%- sc %>
   let { port, hostname } = connection<%- sc %>
   let [ username, password ] = (connection.auth || ':').split(':')<%- sc %>
   let sequelize = new Sequelize(database, username, password, {
@@ -70,7 +70,7 @@ const operatorsAliases = {
   app.set('sequelizeClient', sequelize)<%- sc %>
 
   app.setup = function (...args<%- tplTsOnly(': any[]') -%>) {
-    let result = oldSetup.apply(this, args)<%- sc %>
+    let result = oldSetup.call(this, ...args)<%- sc %>
     <%- insertFragment('func_init') %>
 
     // Set up data relationships

--- a/test-expands/a-specs/service-sequelize-mssql.test-expected/src1/sequelize-mssql.js
+++ b/test-expands/a-specs/service-sequelize-mssql.test-expected/src1/sequelize-mssql.js
@@ -69,7 +69,7 @@ module.exports = function (app) {
   app.set('sequelizeClient', sequelize);
 
   app.setup = function (...args) {
-    let result = oldSetup.apply(this, args);
+    let result = oldSetup.call(this, ...args);
     // !code: func_init // !end
 
     // Set up data relationships


### PR DESCRIPTION
Same as #182 for the mssql adapter, plus a fix for the potentially undefined error that occurs when checking connection path length.