### PR TITLE
Add code insert point in name.service.js around app.use

### DIFF
--- a/generators/writing/templates/src/services/_service/name.service-knex.ejs
+++ b/generators/writing/templates/src/services/_service/name.service-knex.ejs
@@ -19,7 +19,7 @@
   <%- insertFragment('func_init') %>
 
   // Initialize our service with any options it requires
-  app.use('/<%= path %>', createService(options))<%- sc %>
+  <%- insertFragment('extend', `  app.use('/${path}', createService(options))${sc}`) %>
 
   // Get our initialized service so that we can register hooks and filters
   const service = app.service('<%= path %>')<%- sc %>

--- a/generators/writing/templates/src/services/_service/name.service-mongodb.ejs
+++ b/generators/writing/templates/src/services/_service/name.service-mongodb.ejs
@@ -16,7 +16,7 @@
   <%- insertFragment('func_init') %>
 
   // Initialize our service with any options it requires
-  app.use('/<%= path %>', createService(options))<%- sc %>
+  <%- insertFragment('extend', `  app.use('/${path}', createService(options))${sc}`) %>
 
   // Get our initialized service so that we can register hooks
   const service = app.service('<%= path %>')<%- sc %>

--- a/generators/writing/templates/src/services/_service/name.service-rethinkdb.ejs
+++ b/generators/writing/templates/src/services/_service/name.service-rethinkdb.ejs
@@ -18,7 +18,7 @@
   }<%- sc %>
 
   // Initialize our service with any options it requires
-  app.use('/<%= path %>', createService(options))<%- sc %>
+  <%- insertFragment('extend', `  app.use('/${path}', createService(options))${sc}`) %>
 
   // Get our initialized service so that we can register hooks
   const service = app.service('<%= path %>')<%- sc %>

--- a/generators/writing/templates/src/services/_service/name.service.ejs
+++ b/generators/writing/templates/src/services/_service/name.service.ejs
@@ -27,7 +27,7 @@
   <%- insertFragment('options_change') %>
 
   // Initialize our service with any options it requires
-  app.use('/<%= path %>', createService(options))<%- sc %>
+  <%- insertFragment('extend', `  app.use('/${path}', createService(options))${sc}`) %>
 
   // Get our initialized service so that we can register hooks
   const service = app.service('<%= path %>')<%- sc %>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@feathers-plus/generator-feathers-plus",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@feathers-plus/generator-feathers-plus",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@feathers-plus/generator-feathers-plus",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@feathers-plus/generator-feathers-plus",
   "description": "A Yeoman generator to (re)generate a FeathersJS application supporting both REST and GraphQL architectural concepts and their query languages.",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "homepage": "https://github.com/feathers-plus/generator-feathers-plus",
   "main": "lib/",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@feathers-plus/generator-feathers-plus",
   "description": "A Yeoman generator to (re)generate a FeathersJS application supporting both REST and GraphQL architectural concepts and their query languages.",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "homepage": "https://github.com/feathers-plus/generator-feathers-plus",
   "main": "lib/",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@feathers-plus/generator-feathers-plus",
   "description": "A Yeoman generator to (re)generate a FeathersJS application supporting both REST and GraphQL architectural concepts and their query languages.",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "homepage": "https://github.com/feathers-plus/generator-feathers-plus",
   "main": "lib/",
   "keywords": [

--- a/test-expands/a-gens/js/cumulative.test-expected/src1/services/nedb1/nedb1.service.js
+++ b/test-expands/a-gens/js/cumulative.test-expected/src1/services/nedb1/nedb1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/a-gens/js/cumulative.test-expected/src1/services/nedb2/nedb2.service.js
+++ b/test-expands/a-gens/js/cumulative.test-expected/src1/services/nedb2/nedb2.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/a-gens/js/cumulative.test-expected/src1/services/users1/users1.service.js
+++ b/test-expands/a-gens/js/cumulative.test-expected/src1/services/users1/users1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/a-gens/js/test-authentication.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/a-gens/js/test-authentication.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/a-gens/js/test-authentication.test-expected/src1/services/nedb-2/nedb-2.service.js
+++ b/test-expands/a-gens/js/test-authentication.test-expected/src1/services/nedb-2/nedb-2.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/a-gens/js/test-authentication.test-expected/src1/services/users-1/users-1.service.js
+++ b/test-expands/a-gens/js/test-authentication.test-expected/src1/services/users-1/users-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/a-gens/js/test-hook-integ.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/a-gens/js/test-hook-integ.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/a-gens/js/test-hook-integ.test-expected/src1/services/nedb-2/nedb-2.service.js
+++ b/test-expands/a-gens/js/test-hook-integ.test-expected/src1/services/nedb-2/nedb-2.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/a-gens/js/test-hook-integ.test-expected/src1/services/users-1/users-1.service.js
+++ b/test-expands/a-gens/js/test-hook-integ.test-expected/src1/services/users-1/users-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/a-gens/js/test-hook-unit.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/a-gens/js/test-hook-unit.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/a-gens/js/test-hook-unit.test-expected/src1/services/nedb-2/nedb-2.service.js
+++ b/test-expands/a-gens/js/test-hook-unit.test-expected/src1/services/nedb-2/nedb-2.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/a-gens/js/test-hook-unit.test-expected/src1/services/users-1/users-1.service.js
+++ b/test-expands/a-gens/js/test-hook-unit.test-expected/src1/services/users-1/users-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/a-gens/js/test-service.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/a-gens/js/test-service.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/a-gens/js/test-service.test-expected/src1/services/nedb-2/nedb-2.service.js
+++ b/test-expands/a-gens/js/test-service.test-expected/src1/services/nedb-2/nedb-2.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/a-gens/js/test-service.test-expected/src1/services/users-1/users-1.service.js
+++ b/test-expands/a-gens/js/test-service.test-expected/src1/services/users-1/users-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/a-gens/ts/test-authentication.test-expected/src1/services/nedb-1/nedb-1.service.ts
+++ b/test-expands/a-gens/ts/test-authentication.test-expected/src1/services/nedb-1/nedb-1.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/a-gens/ts/test-authentication.test-expected/src1/services/nedb-2/nedb-2.service.ts
+++ b/test-expands/a-gens/ts/test-authentication.test-expected/src1/services/nedb-2/nedb-2.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/a-gens/ts/test-authentication.test-expected/src1/services/users-1/users-1.service.ts
+++ b/test-expands/a-gens/ts/test-authentication.test-expected/src1/services/users-1/users-1.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/a-gens/ts/test-hook-integ.test-expected/src1/services/nedb-1/nedb-1.service.ts
+++ b/test-expands/a-gens/ts/test-hook-integ.test-expected/src1/services/nedb-1/nedb-1.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/a-gens/ts/test-hook-integ.test-expected/src1/services/nedb-2/nedb-2.service.ts
+++ b/test-expands/a-gens/ts/test-hook-integ.test-expected/src1/services/nedb-2/nedb-2.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/a-gens/ts/test-hook-integ.test-expected/src1/services/users-1/users-1.service.ts
+++ b/test-expands/a-gens/ts/test-hook-integ.test-expected/src1/services/users-1/users-1.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/a-gens/ts/test-hook-unit.test-expected/src1/services/nedb-1/nedb-1.service.ts
+++ b/test-expands/a-gens/ts/test-hook-unit.test-expected/src1/services/nedb-1/nedb-1.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/a-gens/ts/test-hook-unit.test-expected/src1/services/nedb-2/nedb-2.service.ts
+++ b/test-expands/a-gens/ts/test-hook-unit.test-expected/src1/services/nedb-2/nedb-2.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/a-gens/ts/test-hook-unit.test-expected/src1/services/users-1/users-1.service.ts
+++ b/test-expands/a-gens/ts/test-hook-unit.test-expected/src1/services/users-1/users-1.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/a-gens/ts/test-service.test-expected/src1/services/nedb-1/nedb-1.service.ts
+++ b/test-expands/a-gens/ts/test-service.test-expected/src1/services/nedb-1/nedb-1.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/a-gens/ts/test-service.test-expected/src1/services/nedb-2/nedb-2.service.ts
+++ b/test-expands/a-gens/ts/test-service.test-expected/src1/services/nedb-2/nedb-2.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/a-gens/ts/test-service.test-expected/src1/services/users-1/users-1.service.ts
+++ b/test-expands/a-gens/ts/test-service.test-expected/src1/services/users-1/users-1.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/a-specs/service-sequelize-mssql.test-expected/src1/services/users/users.service.js
+++ b/test-expands/a-specs/service-sequelize-mssql.test-expected/src1/services/users/users.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users');

--- a/test-expands/authentication-1.test-expected/src1/services/users-1/users-1.service.js
+++ b/test-expands/authentication-1.test-expected/src1/services/users-1/users-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/authentication-2.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/authentication-2.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/authentication-2.test-expected/src1/services/users-1/users-1.service.js
+++ b/test-expands/authentication-2.test-expected/src1/services/users-1/users-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/authentication-3.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/authentication-3.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/authentication-3.test-expected/src1/services/nedb-2/nedb-2.service.js
+++ b/test-expands/authentication-3.test-expected/src1/services/nedb-2/nedb-2.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/authentication-3.test-expected/src1/services/users-1/users-1.service.js
+++ b/test-expands/authentication-3.test-expected/src1/services/users-1/users-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/cumulative-1-generic.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/cumulative-1-generic.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -17,7 +17,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/cumulative-1-generic.test-expected/src1/services/nedb-2/nedb-2.service.js
+++ b/test-expands/cumulative-1-generic.test-expected/src1/services/nedb-2/nedb-2.service.js
@@ -17,7 +17,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/cumulative-1-generic.test-expected/src1/services/users-1/users-1.service.js
+++ b/test-expands/cumulative-1-generic.test-expected/src1/services/users-1/users-1.service.js
@@ -17,7 +17,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/cumulative-1-memory.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/cumulative-1-memory.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -17,7 +17,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/cumulative-1-memory.test-expected/src1/services/nedb-2/nedb-2.service.js
+++ b/test-expands/cumulative-1-memory.test-expected/src1/services/nedb-2/nedb-2.service.js
@@ -17,7 +17,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/cumulative-1-memory.test-expected/src1/services/users-1/users-1.service.js
+++ b/test-expands/cumulative-1-memory.test-expected/src1/services/users-1/users-1.service.js
@@ -17,7 +17,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/cumulative-1-mongo.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/cumulative-1-mongo.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -14,7 +14,9 @@ let moduleExports = function (app) {
   // !code: func_init // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/cumulative-1-mongo.test-expected/src1/services/nedb-2/nedb-2.service.js
+++ b/test-expands/cumulative-1-mongo.test-expected/src1/services/nedb-2/nedb-2.service.js
@@ -14,7 +14,9 @@ let moduleExports = function (app) {
   // !code: func_init // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/cumulative-1-mongo.test-expected/src1/services/users-1/users-1.service.js
+++ b/test-expands/cumulative-1-mongo.test-expected/src1/services/users-1/users-1.service.js
@@ -14,7 +14,9 @@ let moduleExports = function (app) {
   // !code: func_init // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/cumulative-1-mongoose.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/cumulative-1-mongoose.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/cumulative-1-mongoose.test-expected/src1/services/nedb-2/nedb-2.service.js
+++ b/test-expands/cumulative-1-mongoose.test-expected/src1/services/nedb-2/nedb-2.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/cumulative-1-mongoose.test-expected/src1/services/users-1/users-1.service.js
+++ b/test-expands/cumulative-1-mongoose.test-expected/src1/services/users-1/users-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/cumulative-1-nedb.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/cumulative-1-nedb.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/cumulative-1-nedb.test-expected/src1/services/nedb-2/nedb-2.service.js
+++ b/test-expands/cumulative-1-nedb.test-expected/src1/services/nedb-2/nedb-2.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/cumulative-1-nedb.test-expected/src1/services/users-1/users-1.service.js
+++ b/test-expands/cumulative-1-nedb.test-expected/src1/services/users-1/users-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/cumulative-1-no-semicolons.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/cumulative-1-no-semicolons.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options))
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1')

--- a/test-expands/cumulative-1-no-semicolons.test-expected/src1/services/nedb-2/nedb-2.service.js
+++ b/test-expands/cumulative-1-no-semicolons.test-expected/src1/services/nedb-2/nedb-2.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options))
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2')

--- a/test-expands/cumulative-1-no-semicolons.test-expected/src1/services/users-1/users-1.service.js
+++ b/test-expands/cumulative-1-no-semicolons.test-expected/src1/services/users-1/users-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options))
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1')

--- a/test-expands/cumulative-2-hooks.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/cumulative-2-hooks.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/cumulative-2-hooks.test-expected/src1/services/nedb-2/nedb-2.service.js
+++ b/test-expands/cumulative-2-hooks.test-expected/src1/services/nedb-2/nedb-2.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/cumulative-2-hooks.test-expected/src1/services/users-1/users-1.service.js
+++ b/test-expands/cumulative-2-hooks.test-expected/src1/services/users-1/users-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/cumulative-2-nedb-batchloaders.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/cumulative-2-nedb-batchloaders.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/cumulative-2-nedb-batchloaders.test-expected/src1/services/nedb-2/nedb-2.service.js
+++ b/test-expands/cumulative-2-nedb-batchloaders.test-expected/src1/services/nedb-2/nedb-2.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/cumulative-2-nedb-batchloaders.test-expected/src1/services/users-1/users-1.service.js
+++ b/test-expands/cumulative-2-nedb-batchloaders.test-expected/src1/services/users-1/users-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/cumulative-2-sequelize-services.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/cumulative-2-sequelize-services.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/cumulative-2-sequelize-services.test-expected/src1/services/nedb-2/nedb-2.service.js
+++ b/test-expands/cumulative-2-sequelize-services.test-expected/src1/services/nedb-2/nedb-2.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/cumulative-2-sequelize-services.test-expected/src1/services/users-1/users-1.service.js
+++ b/test-expands/cumulative-2-sequelize-services.test-expected/src1/services/users-1/users-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/graphql-auth.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/graphql-auth.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/graphql-auth.test-expected/src1/services/nedb-2/nedb-2.service.js
+++ b/test-expands/graphql-auth.test-expected/src1/services/nedb-2/nedb-2.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/graphql-auth.test-expected/src1/services/users-1/users-1.service.js
+++ b/test-expands/graphql-auth.test-expected/src1/services/users-1/users-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/graphql.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/graphql.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/graphql.test-expected/src1/services/nedb-2/nedb-2.service.js
+++ b/test-expands/graphql.test-expected/src1/services/nedb-2/nedb-2.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/middleware.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/middleware.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/middleware.test-expected/src1/services/nedb-2/nedb-2.service.js
+++ b/test-expands/middleware.test-expected/src1/services/nedb-2/nedb-2.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/name-space.test-expected/src1/services/a-1/b-1/nedb-4/nedb-4.service.js
+++ b/test-expands/name-space.test-expected/src1/services/a-1/b-1/nedb-4/nedb-4.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-4', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-4');

--- a/test-expands/name-space.test-expected/src1/services/a-1/b-1/nedb-5/nedb-5.service.js
+++ b/test-expands/name-space.test-expected/src1/services/a-1/b-1/nedb-5/nedb-5.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-5', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-5');

--- a/test-expands/name-space.test-expected/src1/services/a-1/nedb-2/nedb-2.service.js
+++ b/test-expands/name-space.test-expected/src1/services/a-1/nedb-2/nedb-2.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/name-space.test-expected/src1/services/a-1/nedb-3/nedb-3.service.js
+++ b/test-expands/name-space.test-expected/src1/services/a-1/nedb-3/nedb-3.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-3', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-3');

--- a/test-expands/name-space.test-expected/src1/services/c-1/nedb-6/nedb-6.service.js
+++ b/test-expands/name-space.test-expected/src1/services/c-1/nedb-6/nedb-6.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-6', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-6');

--- a/test-expands/name-space.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/name-space.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/regen-adapters-1.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/regen-adapters-1.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/regen-user-entity.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/regen-user-entity.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/regen-user-entity.test-expected/src1/services/users-1/users-1.service.js
+++ b/test-expands/regen-user-entity.test-expected/src1/services/users-1/users-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/service-naming.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/service-naming.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/service-naming.test-expected/src1/services/nedb-2/nedb-2.service.js
+++ b/test-expands/service-naming.test-expected/src1/services/nedb-2/nedb-2.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/service-naming.test-expected/src1/services/users1/users1.service.js
+++ b/test-expands/service-naming.test-expected/src1/services/users1/users1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/service.test-expected/src1/services/nedb-1/nedb-1.service.js
+++ b/test-expands/service.test-expected/src1/services/nedb-1/nedb-1.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/service.test-expected/src1/services/nedb-2/nedb-2.service.js
+++ b/test-expands/service.test-expected/src1/services/nedb-2/nedb-2.service.js
@@ -19,7 +19,9 @@ let moduleExports = function (app) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/ts-cumulative-1-generic.test-expected/src1/services/nedb-1/nedb-1.service.ts
+++ b/test-expands/ts-cumulative-1-generic.test-expected/src1/services/nedb-1/nedb-1.service.ts
@@ -19,7 +19,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/ts-cumulative-1-generic.test-expected/src1/services/nedb-2/nedb-2.service.ts
+++ b/test-expands/ts-cumulative-1-generic.test-expected/src1/services/nedb-2/nedb-2.service.ts
@@ -19,7 +19,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/ts-cumulative-1-generic.test-expected/src1/services/users-1/users-1.service.ts
+++ b/test-expands/ts-cumulative-1-generic.test-expected/src1/services/users-1/users-1.service.ts
@@ -19,7 +19,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/ts-cumulative-1-memory.test-expected/src1/services/nedb-1/nedb-1.service.ts
+++ b/test-expands/ts-cumulative-1-memory.test-expected/src1/services/nedb-1/nedb-1.service.ts
@@ -19,7 +19,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/ts-cumulative-1-memory.test-expected/src1/services/nedb-2/nedb-2.service.ts
+++ b/test-expands/ts-cumulative-1-memory.test-expected/src1/services/nedb-2/nedb-2.service.ts
@@ -19,7 +19,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/ts-cumulative-1-memory.test-expected/src1/services/users-1/users-1.service.ts
+++ b/test-expands/ts-cumulative-1-memory.test-expected/src1/services/users-1/users-1.service.ts
@@ -19,7 +19,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/ts-cumulative-1-mongo.test-expected/src1/services/nedb-1/nedb-1.service.ts
+++ b/test-expands/ts-cumulative-1-mongo.test-expected/src1/services/nedb-1/nedb-1.service.ts
@@ -17,7 +17,9 @@ let moduleExports = function (app: App) {
   // !code: func_init // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/ts-cumulative-1-mongo.test-expected/src1/services/nedb-2/nedb-2.service.ts
+++ b/test-expands/ts-cumulative-1-mongo.test-expected/src1/services/nedb-2/nedb-2.service.ts
@@ -17,7 +17,9 @@ let moduleExports = function (app: App) {
   // !code: func_init // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/ts-cumulative-1-mongo.test-expected/src1/services/users-1/users-1.service.ts
+++ b/test-expands/ts-cumulative-1-mongo.test-expected/src1/services/users-1/users-1.service.ts
@@ -17,7 +17,9 @@ let moduleExports = function (app: App) {
   // !code: func_init // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/nedb-1/nedb-1.service.ts
+++ b/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/nedb-1/nedb-1.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/nedb-2/nedb-2.service.ts
+++ b/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/nedb-2/nedb-2.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/users-1/users-1.service.ts
+++ b/test-expands/ts-cumulative-1-mongoose.test-expected/src1/services/users-1/users-1.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/ts-cumulative-1-nedb.test-expected/src1/services/nedb-1/nedb-1.service.ts
+++ b/test-expands/ts-cumulative-1-nedb.test-expected/src1/services/nedb-1/nedb-1.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/ts-cumulative-1-nedb.test-expected/src1/services/nedb-2/nedb-2.service.ts
+++ b/test-expands/ts-cumulative-1-nedb.test-expected/src1/services/nedb-2/nedb-2.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/ts-cumulative-1-nedb.test-expected/src1/services/users-1/users-1.service.ts
+++ b/test-expands/ts-cumulative-1-nedb.test-expected/src1/services/users-1/users-1.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/ts-cumulative-2-hooks.test-expected/src1/services/nedb-1/nedb-1.service.ts
+++ b/test-expands/ts-cumulative-2-hooks.test-expected/src1/services/nedb-1/nedb-1.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/ts-cumulative-2-hooks.test-expected/src1/services/nedb-2/nedb-2.service.ts
+++ b/test-expands/ts-cumulative-2-hooks.test-expected/src1/services/nedb-2/nedb-2.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/ts-cumulative-2-hooks.test-expected/src1/services/users-1/users-1.service.ts
+++ b/test-expands/ts-cumulative-2-hooks.test-expected/src1/services/users-1/users-1.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/ts-cumulative-2-sequelize-services.test-expected/src1/services/nedb-1/nedb-1.service.ts
+++ b/test-expands/ts-cumulative-2-sequelize-services.test-expected/src1/services/nedb-1/nedb-1.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');

--- a/test-expands/ts-cumulative-2-sequelize-services.test-expected/src1/services/nedb-2/nedb-2.service.ts
+++ b/test-expands/ts-cumulative-2-sequelize-services.test-expected/src1/services/nedb-2/nedb-2.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/ts-cumulative-2-sequelize-services.test-expected/src1/services/users-1/users-1.service.ts
+++ b/test-expands/ts-cumulative-2-sequelize-services.test-expected/src1/services/users-1/users-1.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/users-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('users-1');

--- a/test-expands/ts-name-space.test-expected/src1/services/a-1/b-1/nedb-4/nedb-4.service.ts
+++ b/test-expands/ts-name-space.test-expected/src1/services/a-1/b-1/nedb-4/nedb-4.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-4', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-4');

--- a/test-expands/ts-name-space.test-expected/src1/services/a-1/b-1/nedb-5/nedb-5.service.ts
+++ b/test-expands/ts-name-space.test-expected/src1/services/a-1/b-1/nedb-5/nedb-5.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-5', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-5');

--- a/test-expands/ts-name-space.test-expected/src1/services/a-1/nedb-2/nedb-2.service.ts
+++ b/test-expands/ts-name-space.test-expected/src1/services/a-1/nedb-2/nedb-2.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-2', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-2');

--- a/test-expands/ts-name-space.test-expected/src1/services/a-1/nedb-3/nedb-3.service.ts
+++ b/test-expands/ts-name-space.test-expected/src1/services/a-1/nedb-3/nedb-3.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-3', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-3');

--- a/test-expands/ts-name-space.test-expected/src1/services/c-1/nedb-6/nedb-6.service.ts
+++ b/test-expands/ts-name-space.test-expected/src1/services/c-1/nedb-6/nedb-6.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-6', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-6');

--- a/test-expands/ts-name-space.test-expected/src1/services/nedb-1/nedb-1.service.ts
+++ b/test-expands/ts-name-space.test-expected/src1/services/nedb-1/nedb-1.service.ts
@@ -21,7 +21,9 @@ let moduleExports = function (app: App) {
   // !code: options_change // !end
 
   // Initialize our service with any options it requires
+  // !<DEFAULT> code: extend
   app.use('/nedb-1', createService(options));
+  // !end
 
   // Get our initialized service so that we can register hooks
   const service = app.service('nedb-1');


### PR DESCRIPTION
```js
  // !<DEFAULT> code: extend
  app.use('/users', createService(options));
  // !end
```
allows devs to extend a service, e.g.
```js
app.use('/sequence', new SequenceService(options));
```