### PR TITLE
docs: Add description for ctx.dataCurrIndex

### DIFF
--- a/docs/get-started/README.md
+++ b/docs/get-started/README.md
@@ -1748,6 +1748,7 @@ You can use it in any valid JavaScript expression.
 - Other conveniences are also passed to the expression in the `ctx` object.
     - **ctx.data** (Array< Object >) - All the generated records for all the services.
     Values for foreign keys and expressions have been calculated up to the current record.
+    - **ctx.dataCurrIndex** (Number) - Index of the current record.
     - **ctx.hashPassword** (Function(password)) - Calculates a password hash
     compatible with Feathers' `hashPassword` hook.
     This password will work correctly with Feathers local authentication.


### PR DESCRIPTION
### Summary

adds documentation for https://github.com/feathers-plus/seeder-foreign-keys/pull/1

ctx object now contains a property dataCurrIndex which holds the array index of the current record being created.