### PR TITLE
Add script for packaging application in executable binary using nexe

### DIFF
--- a/generators/writing/app.js
+++ b/generators/writing/app.js
@@ -242,6 +242,7 @@ function app (generator, props, specs, context, state) {
 
   generator.devDependencies = [
     'mocha',
+    'nexe',
     'nodemon',
     'request',
     'request-promise'

--- a/generators/writing/templates/_configs/package.json.js
+++ b/generators/writing/templates/_configs/package.json.js
@@ -11,7 +11,7 @@ module.exports = function(generator) {
     description: specs.app.description,
     version: '0.0.0',
     homepage: '',
-    main: specs.app.src,
+    main: specs.options.ts ? `compiled/index.js` : `${specs.app.src}/index.js`,
     keywords: [
       'feathers'
     ],
@@ -43,6 +43,7 @@ module.exports = function(generator) {
     'start:seed': 'cross-env NODE_ENV= ts-node --files src/ --seed',
     mocha: 'ts-mocha -p tsconfig.test.json "test/**/*.test.ts" --timeout 10000 --exit',
     compile: 'tsc -p tsconfig.json',
+    package: `${packager} run compile && nexe --build -o ${specs.app.name}`
   } : {
     test: `${packager} run eslint && ${packager} run mocha`,
     'test:all': `${packager} run eslint && cross-env NODE_ENV= npm run mocha`,
@@ -51,7 +52,8 @@ module.exports = function(generator) {
     'dev:seed': `nodemon ${specs.app.src}/ --seed`,
     start: `node ${specs.app.src}/`,
     'start:seed': 'cross-env NODE_ENV= node src/ --seed',
-    mocha: 'mocha test/ --recursive --exit --timeout 10000'
+    mocha: 'mocha test/ --recursive --exit --timeout 10000',
+    package: `nexe --build -o ${specs.app.name}`
   });
 
   return pkg;

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "mongodb": "^3.1.1",
     "mongoose": "^5.2.7",
     "nedb": "^1.8.0",
+    "nexe": "^3.0.0-beta.15",
     "nodemon": "^1.18.7",
     "passport-auth0": "^1.0.0",
     "passport-google-oauth20": "^1.0.0",

--- a/test-expands/a-gens/js/cumulative.test-expected/package.json
+++ b/test-expands/a-gens/js/cumulative.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/a-gens/js/test-authentication.test-expected/package.json
+++ b/test-expands/a-gens/js/test-authentication.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/a-gens/js/test-hook-integ.test-expected/package.json
+++ b/test-expands/a-gens/js/test-hook-integ.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/a-gens/js/test-hook-unit.test-expected/package.json
+++ b/test-expands/a-gens/js/test-hook-unit.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/a-gens/js/test-service.test-expected/package.json
+++ b/test-expands/a-gens/js/test-service.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/a-gens/ts/test-authentication.test-expected/package.json
+++ b/test-expands/a-gens/ts/test-authentication.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "compiled/index.js",
   "keywords": [
     "feathers"
   ],
@@ -30,6 +30,7 @@
     "start": "ts-node --files src1/",
     "start:seed": "cross-env NODE_ENV=test ts-node --files src/ --seed",
     "mocha": "ts-mocha -p tsconfig.test.json \"test/**/*.test.ts\" --timeout 10000 --exit",
-    "compile": "tsc -p tsconfig.json"
+    "compile": "tsc -p tsconfig.json",
+    "package": "npm run compile && nexe --build -o z-1"
   }
 }

--- a/test-expands/a-gens/ts/test-hook-integ.test-expected/package.json
+++ b/test-expands/a-gens/ts/test-hook-integ.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "compiled/index.js",
   "keywords": [
     "feathers"
   ],
@@ -30,6 +30,7 @@
     "start": "ts-node --files src1/",
     "start:seed": "cross-env NODE_ENV=test ts-node --files src/ --seed",
     "mocha": "ts-mocha -p tsconfig.test.json \"test/**/*.test.ts\" --timeout 10000 --exit",
-    "compile": "tsc -p tsconfig.json"
+    "compile": "tsc -p tsconfig.json",
+    "package": "npm run compile && nexe --build -o z-1"
   }
 }

--- a/test-expands/a-gens/ts/test-hook-unit.test-expected/package.json
+++ b/test-expands/a-gens/ts/test-hook-unit.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "compiled/index.js",
   "keywords": [
     "feathers"
   ],
@@ -30,6 +30,7 @@
     "start": "ts-node --files src1/",
     "start:seed": "cross-env NODE_ENV=test ts-node --files src/ --seed",
     "mocha": "ts-mocha -p tsconfig.test.json \"test/**/*.test.ts\" --timeout 10000 --exit",
-    "compile": "tsc -p tsconfig.json"
+    "compile": "tsc -p tsconfig.json",
+    "package": "npm run compile && nexe --build -o z-1"
   }
 }

--- a/test-expands/a-gens/ts/test-service.test-expected/package.json
+++ b/test-expands/a-gens/ts/test-service.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "compiled/index.js",
   "keywords": [
     "feathers"
   ],
@@ -30,6 +30,7 @@
     "start": "ts-node --files src1/",
     "start:seed": "cross-env NODE_ENV=test ts-node --files src/ --seed",
     "mocha": "ts-mocha -p tsconfig.test.json \"test/**/*.test.ts\" --timeout 10000 --exit",
-    "compile": "tsc -p tsconfig.json"
+    "compile": "tsc -p tsconfig.json",
+    "package": "npm run compile && nexe --build -o z-1"
   }
 }

--- a/test-expands/a-specs/service-sequelize-mssql.test-expected/package.json
+++ b/test-expands/a-specs/service-sequelize-mssql.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/app-code-blocks.test-expected/package.json
+++ b/test-expands/app-code-blocks.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=testa node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/app-eslintrc.test-expected/package.json
+++ b/test-expands/app-eslintrc.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/app-freeze.test-expected/package.json
+++ b/test-expands/app-freeze.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/app.test-expected/package.json
+++ b/test-expands/app.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=testa node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/authentication-1.test-expected/package.json
+++ b/test-expands/authentication-1.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/authentication-2.test-expected/package.json
+++ b/test-expands/authentication-2.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/authentication-3.test-expected/package.json
+++ b/test-expands/authentication-3.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/cumulative-1-generic.test-expected/package.json
+++ b/test-expands/cumulative-1-generic.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/cumulative-1-memory.test-expected/package.json
+++ b/test-expands/cumulative-1-memory.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/cumulative-1-mongo.test-expected/package.json
+++ b/test-expands/cumulative-1-mongo.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/cumulative-1-mongoose.test-expected/package.json
+++ b/test-expands/cumulative-1-mongoose.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/cumulative-1-nedb.test-expected/package.json
+++ b/test-expands/cumulative-1-nedb.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/cumulative-1-no-semicolons.test-expected/package.json
+++ b/test-expands/cumulative-1-no-semicolons.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/cumulative-2-hooks.test-expected/package.json
+++ b/test-expands/cumulative-2-hooks.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/cumulative-2-nedb-batchloaders.test-expected/package.json
+++ b/test-expands/cumulative-2-nedb-batchloaders.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/cumulative-2-sequelize-services.test-expected/package.json
+++ b/test-expands/cumulative-2-sequelize-services.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/graphql-auth.test-expected/package.json
+++ b/test-expands/graphql-auth.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/graphql.test-expected/package.json
+++ b/test-expands/graphql.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/middleware.test-expected/package.json
+++ b/test-expands/middleware.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/name-space.test-expected/package.json
+++ b/test-expands/name-space.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/regen-adapters-1.test-expected/package.json
+++ b/test-expands/regen-adapters-1.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/regen-user-entity.test-expected/package.json
+++ b/test-expands/regen-user-entity.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/scaffolding.test-expected/package.json
+++ b/test-expands/scaffolding.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/service-naming.test-expected/package.json
+++ b/test-expands/service-naming.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/service.test-expected/package.json
+++ b/test-expands/service.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "src1/index.js",
   "keywords": [
     "feathers"
   ],
@@ -29,6 +29,7 @@
     "dev:seed": "nodemon src1/ --seed",
     "start": "node src1/",
     "start:seed": "cross-env NODE_ENV=test node src/ --seed",
-    "mocha": "mocha test/ --recursive --exit --timeout 10000"
+    "mocha": "mocha test/ --recursive --exit --timeout 10000",
+    "package": "nexe --build -o z-1"
   }
 }

--- a/test-expands/ts-cumulative-1-generic.test-expected/package.json
+++ b/test-expands/ts-cumulative-1-generic.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "compiled/index.js",
   "keywords": [
     "feathers"
   ],
@@ -30,6 +30,7 @@
     "start": "ts-node --files src1/",
     "start:seed": "cross-env NODE_ENV=test ts-node --files src/ --seed",
     "mocha": "ts-mocha -p tsconfig.test.json \"test/**/*.test.ts\" --timeout 10000 --exit",
-    "compile": "tsc -p tsconfig.json"
+    "compile": "tsc -p tsconfig.json",
+    "package": "npm run compile && nexe --build -o z-1"
   }
 }

--- a/test-expands/ts-cumulative-1-memory.test-expected/package.json
+++ b/test-expands/ts-cumulative-1-memory.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "compiled/index.js",
   "keywords": [
     "feathers"
   ],
@@ -30,6 +30,7 @@
     "start": "ts-node --files src1/",
     "start:seed": "cross-env NODE_ENV=test ts-node --files src/ --seed",
     "mocha": "ts-mocha -p tsconfig.test.json \"test/**/*.test.ts\" --timeout 10000 --exit",
-    "compile": "tsc -p tsconfig.json"
+    "compile": "tsc -p tsconfig.json",
+    "package": "npm run compile && nexe --build -o z-1"
   }
 }

--- a/test-expands/ts-cumulative-1-mongo.test-expected/package.json
+++ b/test-expands/ts-cumulative-1-mongo.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "compiled/index.js",
   "keywords": [
     "feathers"
   ],
@@ -30,6 +30,7 @@
     "start": "ts-node --files src1/",
     "start:seed": "cross-env NODE_ENV=test ts-node --files src/ --seed",
     "mocha": "ts-mocha -p tsconfig.test.json \"test/**/*.test.ts\" --timeout 10000 --exit",
-    "compile": "tsc -p tsconfig.json"
+    "compile": "tsc -p tsconfig.json",
+    "package": "npm run compile && nexe --build -o z-1"
   }
 }

--- a/test-expands/ts-cumulative-1-mongoose.test-expected/package.json
+++ b/test-expands/ts-cumulative-1-mongoose.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "compiled/index.js",
   "keywords": [
     "feathers"
   ],
@@ -30,6 +30,7 @@
     "start": "ts-node --files src1/",
     "start:seed": "cross-env NODE_ENV=test ts-node --files src/ --seed",
     "mocha": "ts-mocha -p tsconfig.test.json \"test/**/*.test.ts\" --timeout 10000 --exit",
-    "compile": "tsc -p tsconfig.json"
+    "compile": "tsc -p tsconfig.json",
+    "package": "npm run compile && nexe --build -o z-1"
   }
 }

--- a/test-expands/ts-cumulative-1-nedb.test-expected/package.json
+++ b/test-expands/ts-cumulative-1-nedb.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "compiled/index.js",
   "keywords": [
     "feathers"
   ],
@@ -30,6 +30,7 @@
     "start": "ts-node --files src1/",
     "start:seed": "cross-env NODE_ENV=test ts-node --files src/ --seed",
     "mocha": "ts-mocha -p tsconfig.test.json \"test/**/*.test.ts\" --timeout 10000 --exit",
-    "compile": "tsc -p tsconfig.json"
+    "compile": "tsc -p tsconfig.json",
+    "package": "npm run compile && nexe --build -o z-1"
   }
 }

--- a/test-expands/ts-cumulative-2-hooks.test-expected/package.json
+++ b/test-expands/ts-cumulative-2-hooks.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "compiled/index.js",
   "keywords": [
     "feathers"
   ],
@@ -30,6 +30,7 @@
     "start": "ts-node --files src1/",
     "start:seed": "cross-env NODE_ENV=test ts-node --files src/ --seed",
     "mocha": "ts-mocha -p tsconfig.test.json \"test/**/*.test.ts\" --timeout 10000 --exit",
-    "compile": "tsc -p tsconfig.json"
+    "compile": "tsc -p tsconfig.json",
+    "package": "npm run compile && nexe --build -o z-1"
   }
 }

--- a/test-expands/ts-cumulative-2-sequelize-services.test-expected/package.json
+++ b/test-expands/ts-cumulative-2-sequelize-services.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "compiled/index.js",
   "keywords": [
     "feathers"
   ],
@@ -30,6 +30,7 @@
     "start": "ts-node --files src1/",
     "start:seed": "cross-env NODE_ENV=test ts-node --files src/ --seed",
     "mocha": "ts-mocha -p tsconfig.test.json \"test/**/*.test.ts\" --timeout 10000 --exit",
-    "compile": "tsc -p tsconfig.json"
+    "compile": "tsc -p tsconfig.json",
+    "package": "npm run compile && nexe --build -o z-1"
   }
 }

--- a/test-expands/ts-name-space.test-expected/package.json
+++ b/test-expands/ts-name-space.test-expected/package.json
@@ -3,7 +3,7 @@
   "description": "Project z-1",
   "version": "0.0.0",
   "homepage": "",
-  "main": "src1",
+  "main": "compiled/index.js",
   "keywords": [
     "feathers"
   ],
@@ -30,6 +30,7 @@
     "start": "ts-node --files src1/",
     "start:seed": "cross-env NODE_ENV=test ts-node --files src/ --seed",
     "mocha": "ts-mocha -p tsconfig.test.json \"test/**/*.test.ts\" --timeout 10000 --exit",
-    "compile": "tsc -p tsconfig.json"
+    "compile": "tsc -p tsconfig.json",
+    "package": "npm run compile && nexe --build -o z-1"
   }
 }


### PR DESCRIPTION
### Summary

This pull request adds a script using nexe to package a feathers-plus application in an executable binary for production. Tests have also been updated to account for the script.

See #128 for additional context concerning microservices and why nexe was used rather than @zeit/pkg to compile the binary.

### Known issues

More of a notice than an issue, but the provided script builds for the platform on which the binary is created. To create a binary for a different platform (say alpine), use the `--target` flag to provide the desired platform. See the documentation for [nexe](https://github.com/nexe/nexe.git) for additional options