### PR TITLE
Allow subdirectory parsing with dot paths

### DIFF
--- a/docs/get-started/README.md
+++ b/docs/get-started/README.md
@@ -3015,6 +3015,11 @@ cli-plus will not overwrite any module names you add to *freeze*. For example
 "freeze": ["src/hooks/logger.js"]
 ```
 
+cli-plus will exclude any paths you add to *ignore*. For example
+```js
+"ignore": ["client/**"]
+```
+
 #### Custom code
 
 You can list all the custom code in your app using

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -14,6 +14,7 @@ This contains primarily the responses provided to the prompts used to create the
     "inspectConflicts": false,
     "semicolons": true,
     "freeze": [],
+    "ignore": [],
     "ts": false
   },
   "app": {

--- a/lib/code-fragments.js
+++ b/lib/code-fragments.js
@@ -27,12 +27,12 @@ function resetForTest () {
   destinationRoot = undefined;
 }
 
-async function refreshCodeFragments (destinationRoot1) {
+async function refreshCodeFragments (destinationRoot1, options = {}) {
   destinationRoot = destinationRoot1;
 
   try {
     const startTime = process.hrtime();
-    await extractProject();
+    await extractProject(options);
     const diffTime = process.hrtime(startTime);
     console.log('Source scan took %ds %dms', diffTime[0], Math.round(diffTime[1]/1000000));
     console.log('');
@@ -42,13 +42,14 @@ async function refreshCodeFragments (destinationRoot1) {
     }
 }
 
-async function extractProject () {
+async function extractProject (options = {}) {
   try {
+    const ignore = (options.ignore || []).map( path => `${destinationRoot}/${path}` );
     const files = glob.sync(
       `${destinationRoot}/**/*.{js,ts}`, { ignore: [
           `${destinationRoot}/**/node_modules/**`,
           `${destinationRoot}/public/**`
-        ]}
+        ].concat(ignore)}
     );
 
     // Make feathers-gen-code.?s the first module as it contains default code blocks

--- a/lib/code-fragments.js
+++ b/lib/code-fragments.js
@@ -1,6 +1,6 @@
 
 const glob = require('glob');
-const { existsSync, readFileSync } = require('fs');
+const { existsSync, readFileSync, lstatSync } = require('fs');
 
 const EOL = '\n';
 const moduleHeaders = ['// !module', '//!module', '// ! module'];
@@ -94,7 +94,11 @@ async function extractFiles (filePaths, ifCheck) {
       if (ifCheck && !(await existsSync(filePath))) {
         break;
       }
-
+      
+      if( await lstatSync(filePath).isDirectory() ) {
+        break;
+      }
+      
       const src = await readFileSync(filePath, 'utf8');
       extractSource(filePath, src.split(EOL));
     }

--- a/lib/service-specs-to-mongoose.js
+++ b/lib/service-specs-to-mongoose.js
@@ -49,7 +49,8 @@ const keywordEquivalence = {
  unique: null, // boolean
  sparse: null, // boolean
  nullable: null, // boolean
- default: null //any
+ default: null, //any
+ description: 'description' // used for swagger usage
 };
 
 const discardFields = ['id', '_id'];
@@ -147,6 +148,8 @@ function copyOtherMongooseAttributes(property,mongooseProperty)
     {
       let equivalence = keywordEquivalence[attributeName] || attributeName;
       mongooseProperty[equivalence] = property[attributeName];
+    } else {
+      console.log(attributeName)
     }
   });
 }

--- a/lib/specs.js
+++ b/lib/specs.js
@@ -89,7 +89,7 @@ async function setPath (generator1) {
     stashedSpecs._isRunningTests = root.startsWith('/private/') || (root.indexOf(tmpdir()) !== -1);
 
     // Extract custom code
-    await refreshCodeFragments(generator.destinationRoot());
+    await refreshCodeFragments(generator.destinationRoot(), stashedSpecs.options);
   }
 
   /*


### PR DESCRIPTION


### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [X] Tell us about the problem your pull request is solving.
In some cases, subpath like "**/chart.js" may contains a dot, this type of directories wasn't reject from **extractFiles**
For large project no only with feathers code, want to exclude, not freeze, some directories or files
For swagger generation, missing field description
- [X] Are there any open issues that are related to this?
No
- [x] Is this PR dependent on PRs in other repos?
No

If so, please mention them to keep the conversations linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Your PR will be reviewed by a core team member and they will work with you to get your changes merged in a timely manner. If merged your PR will automatically be added to the changelog in the next release.

If your changes involve documentation updates please mention that and link the appropriate PR in [feathers-docs](https://github.com/feathersjs/feathers-docs).

Thanks for contributing to Feathers! :heart: