### PR TITLE
Expose missing "items" property as error and name of schema

### DIFF
--- a/lib/service-specs-to-mongoose.js
+++ b/lib/service-specs-to-mongoose.js
@@ -73,6 +73,7 @@ function serviceSpecsToMongoose (feathersSpec, feathersExtension, depth = 1) {
     switch (type) {
       case 'array':
         items = Array.isArray(property.items) ? property.items : [property.items];
+        if (!items) throw new Error(`Expected property "items" on schema ${name} is missing for type "array"`);
         mongooseProperty = serviceSpecsProcessArray(items, mongooseProperty, mongooseSchema, name, feathersExtension, depth);
         break;
       case 'object':


### PR DESCRIPTION
When using the type `array` we should be informed about a missing `items` property which defines "what the children are".