### PR TITLE
bugfix: Including default "finally" hook. The fixe includes the property required by type HooksObject.

### DIFF
--- a/examples/ts/10-hook/feathers-app/src/services/graphql/graphql.hooks.ts
+++ b/examples/ts/10-hook/feathers-app/src/services/graphql/graphql.hooks.ts
@@ -47,6 +47,18 @@ let moduleExports: HooksObject = {
     remove: []
     // !end
   },
+  
+  finally: {
+    // !<DEFAULT> code: finally
+    all: [ log() ],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+    // !end
+  },
   // !code: moduleExports // !end
 };
 


### PR DESCRIPTION
### Summary

- Tested on CLI Plus Version: 0.8.10
- The error occurs in a new project when running `yarn start` for the first time after `feathers-plus generate app`.  (See my feathers-gen-specs.json below if needed.)

### Details of Error Message

```
yarn run v1.13.0
$ ts-node --files src/

/Volumes/dev/camera-challenge-fjs/node_modules/ts-node/src/index.ts:261
    return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
src/app.hooks.ts(15,5): error TS2741: Property 'finally' is missing in type '{ before: { all: Hook[]; find: never[]; get: never[]; create: never[]; update: never[]; patch: never[]; remove: never[]; }; after: { all: Hook[]; find: never[]; get: never[]; create: never[]; update: never[]; patch: never[]; remove: never[]; }; error: { ...; }; }' but required in type 'HooksObject'.
```

### The feathers-gen-specs.json if needed to reproduce error

```
{
  "options": {
    "ver": "1.0.0",
    "inspectConflicts": false,
    "semicolons": true,
    "freeze": [],
    "ts": true
  },
  "app": {
    "environmentsAllowingSeedData": "",
    "seedData": false,
    "name": "camera-challenge-fjs",
    "description": "Project camera-challenge-fjs",
    "src": "src",
    "packager": "yarn@>= 0.18.0",
    "providers": [
      "rest",
      "socketio"
    ]
  },
  "services": {},
  "hooks": {}
}
```